### PR TITLE
Add tensorflow support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,60 @@
+version: 2
+
+jobs:
+  test-3.7: &test-template
+    docker:
+      - image: circleci/python:3.7
+
+    working_directory: ~/repo
+
+    steps:
+
+      - checkout
+
+      - run:
+          name: Install dependencies
+          command: |
+            export PATH=$PATH:$HOME/.local/bin
+            pip install -Uq virtualenv --user
+            mkdir -p ./venv
+            virtualenv ./venv
+            . venv/bin/activate
+            pip install -Uq pip
+            pip install -q tensorflow hypothesis
+            pip install -U --no-build-isolation .
+
+      - run:
+          name: Run tests
+          command: |
+            . venv/bin/activate
+            cd tests
+            python -m unittest discover .
+
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports
+
+  test-3.6:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.6
+  test-3.5:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.5
+  test-osx:
+    <<: *test-template
+    docker: null
+    macos:
+      xcode: 11.3.0
+    environment:
+      - ARCHFLAGS: -std=c++11
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test-3.5
+      - test-3.6
+      - test-3.7
+      - test-osx

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,6 @@ jobs:
     docker: null
     macos:
       xcode: 11.3.0
-    environment:
-      - ARCHFLAGS: -std=c++11
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@
 fsph is a library to efficiently compute series of spherical harmonics (i.e. all of Y<sub>l</sub><sup>m</sup> for a set of l).
 
 It is based on math enumerated by Martin J. Mohlenkamp at http://www.ohio.edu/people/mohlenka/research/uguide.pdf.
+
+fsph uses portions of the cuda_complex project, located at
+https://github.com/jtravs/cuda_complex.git . Its code and license are
+located in the cuda_complex subdirectory.

--- a/cuda_complex/LICENSE.txt
+++ b/cuda_complex/LICENSE.txt
@@ -1,0 +1,76 @@
+==============================================================================
+libc++ License
+==============================================================================
+
+The libc++ library is dual licensed under both the University of Illinois
+"BSD-Like" license and the MIT license.  As a user of this code you may choose
+to use it under either license.  As a contributor, you agree to allow your code
+to be used under both.
+
+Full text of the relevant licenses is included below.
+
+==============================================================================
+
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2009-2012 by the contributors listed in CREDITS.TXT
+
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.
+
+==============================================================================
+
+Copyright (c) 2009-2012 by the contributors listed in CREDITS.TXT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/cuda_complex/README.txt
+++ b/cuda_complex/README.txt
@@ -1,0 +1,15 @@
+This is an implementation of C++ std::complex for use on CUDA devices.
+Written by John C. Travers <jtravs@gmail.com> (2012).
+
+Apart from nvcc, it should also work wih any C++03 compiler.
+It is quiet complete. As far as I can tell the only missing features are:
+  - long double support (not supported on CUDA)
+  - some integral pow functions (due to lack of C++11 support on CUDA)
+
+This code is heavily derived from the LLVM libcpp project
+(svn revision 147853), mainly libcxx/include/complex. The git history
+contains the complete change history from the original.
+
+The modifications are licensed as per the original LLVM license, which is dual
+licensed under the MIT and the University of Illinois Open Source Licenses.
+See LICENSE.TXT for details.

--- a/cuda_complex/cuda_complex.hpp
+++ b/cuda_complex/cuda_complex.hpp
@@ -1,0 +1,1335 @@
+// An implementation of C++ std::complex for use on CUDA devices.
+// Written by John C. Travers <jtravs@gmail.com> (2012)
+//
+// Missing:
+//  - long double support (not supported on CUDA)
+//  - some integral pow functions (due to lack of C++11 support on CUDA)
+//
+// Heavily derived from the LLVM libcpp project (svn revision 147853).
+// Based on libcxx/include/complex.
+// The git history contains the complete change history from the original.
+// The modifications are licensed as per the original LLVM license below.
+//
+// -*- C++ -*-
+//===--------------------------- complex ----------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CUDA_COMPLEX_HPP
+#define CUDA_COMPLEX_HPP
+
+#ifdef __CUDACC__
+#define CUDA_CALLABLE_MEMBER __host__ __device__
+#else
+#define CUDA_CALLABLE_MEMBER
+#endif
+
+/*
+    complex synopsis
+
+template<class T>
+class complex
+{
+public:
+    typedef T value_type;
+
+    complex(const T& re = T(), const T& im = T());
+    complex(const complex&);
+    template<class X> complex(const complex<X>&);
+
+    T real() const;
+    T imag() const;
+
+    void real(T);
+    void imag(T);
+
+    complex<T>& operator= (const T&);
+    complex<T>& operator+=(const T&);
+    complex<T>& operator-=(const T&);
+    complex<T>& operator*=(const T&);
+    complex<T>& operator/=(const T&);
+
+    complex& operator=(const complex&);
+    template<class X> complex<T>& operator= (const complex<X>&);
+    template<class X> complex<T>& operator+=(const complex<X>&);
+    template<class X> complex<T>& operator-=(const complex<X>&);
+    template<class X> complex<T>& operator*=(const complex<X>&);
+    template<class X> complex<T>& operator/=(const complex<X>&);
+};
+
+template<>
+class complex<float>
+{
+public:
+    typedef float value_type;
+
+    constexpr complex(float re = 0.0f, float im = 0.0f);
+    explicit constexpr complex(const complex<double>&);
+
+    constexpr float real() const;
+    void real(float);
+    constexpr float imag() const;
+    void imag(float);
+
+    complex<float>& operator= (float);
+    complex<float>& operator+=(float);
+    complex<float>& operator-=(float);
+    complex<float>& operator*=(float);
+    complex<float>& operator/=(float);
+
+    complex<float>& operator=(const complex<float>&);
+    template<class X> complex<float>& operator= (const complex<X>&);
+    template<class X> complex<float>& operator+=(const complex<X>&);
+    template<class X> complex<float>& operator-=(const complex<X>&);
+    template<class X> complex<float>& operator*=(const complex<X>&);
+    template<class X> complex<float>& operator/=(const complex<X>&);
+};
+
+template<>
+class complex<double>
+{
+public:
+    typedef double value_type;
+
+    constexpr complex(double re = 0.0, double im = 0.0);
+    constexpr complex(const complex<float>&);
+
+    constexpr double real() const;
+    void real(double);
+    constexpr double imag() const;
+    void imag(double);
+
+    complex<double>& operator= (double);
+    complex<double>& operator+=(double);
+    complex<double>& operator-=(double);
+    complex<double>& operator*=(double);
+    complex<double>& operator/=(double);
+    complex<double>& operator=(const complex<double>&);
+
+    template<class X> complex<double>& operator= (const complex<X>&);
+    template<class X> complex<double>& operator+=(const complex<X>&);
+    template<class X> complex<double>& operator-=(const complex<X>&);
+    template<class X> complex<double>& operator*=(const complex<X>&);
+    template<class X> complex<double>& operator/=(const complex<X>&);
+};
+
+// 26.3.6 operators:
+template<class T> complex<T> operator+(const complex<T>&, const complex<T>&);
+template<class T> complex<T> operator+(const complex<T>&, const T&);
+template<class T> complex<T> operator+(const T&, const complex<T>&);
+template<class T> complex<T> operator-(const complex<T>&, const complex<T>&);
+template<class T> complex<T> operator-(const complex<T>&, const T&);
+template<class T> complex<T> operator-(const T&, const complex<T>&);
+template<class T> complex<T> operator*(const complex<T>&, const complex<T>&);
+template<class T> complex<T> operator*(const complex<T>&, const T&);
+template<class T> complex<T> operator*(const T&, const complex<T>&);
+template<class T> complex<T> operator/(const complex<T>&, const complex<T>&);
+template<class T> complex<T> operator/(const complex<T>&, const T&);
+template<class T> complex<T> operator/(const T&, const complex<T>&);
+template<class T> complex<T> operator+(const complex<T>&);
+template<class T> complex<T> operator-(const complex<T>&);
+template<class T> bool operator==(const complex<T>&, const complex<T>&);
+template<class T> bool operator==(const complex<T>&, const T&);
+template<class T> bool operator==(const T&, const complex<T>&);
+template<class T> bool operator!=(const complex<T>&, const complex<T>&);
+template<class T> bool operator!=(const complex<T>&, const T&);
+template<class T> bool operator!=(const T&, const complex<T>&);
+
+template<class T, class charT, class traits>
+  basic_istream<charT, traits>&
+  operator>>(basic_istream<charT, traits>&, complex<T>&);
+template<class T, class charT, class traits>
+  basic_ostream<charT, traits>&
+  operator<<(basic_ostream<charT, traits>&, const complex<T>&);
+
+// 26.3.7 values:
+
+template<class T>              T real(const complex<T>&);
+                          double real(double);
+template<Integral T>      double real(T);
+                          float  real(float);
+
+template<class T>              T imag(const complex<T>&);
+                          double imag(double);
+template<Integral T>      double imag(T);
+                          float  imag(float);
+
+template<class T> T abs(const complex<T>&);
+
+template<class T>              T arg(const complex<T>&);
+                          double arg(double);
+template<Integral T>      double arg(T);
+                          float  arg(float);
+
+template<class T>              T norm(const complex<T>&);
+                          double norm(double);
+template<Integral T>      double norm(T);
+                          float  norm(float);
+
+template<class T>      complex<T>           conj(const complex<T>&);
+                       complex<double>      conj(double);
+template<Integral T>   complex<double>      conj(T);
+                       complex<float>       conj(float);
+
+template<class T>    complex<T>           proj(const complex<T>&);
+                     complex<double>      proj(double);
+template<Integral T> complex<double>      proj(T);
+                     complex<float>       proj(float);
+
+template<class T> complex<T> polar(const T&, const T& = 0);
+
+// 26.3.8 transcendentals:
+template<class T> complex<T> acos(const complex<T>&);
+template<class T> complex<T> asin(const complex<T>&);
+template<class T> complex<T> atan(const complex<T>&);
+template<class T> complex<T> acosh(const complex<T>&);
+template<class T> complex<T> asinh(const complex<T>&);
+template<class T> complex<T> atanh(const complex<T>&);
+template<class T> complex<T> cos (const complex<T>&);
+template<class T> complex<T> cosh (const complex<T>&);
+template<class T> complex<T> exp (const complex<T>&);
+template<class T> complex<T> log (const complex<T>&);
+template<class T> complex<T> log10(const complex<T>&);
+
+template<class T> complex<T> pow(const complex<T>&, const T&);
+template<class T> complex<T> pow(const complex<T>&, const complex<T>&);
+template<class T> complex<T> pow(const T&, const complex<T>&);
+
+template<class T> complex<T> sin (const complex<T>&);
+template<class T> complex<T> sinh (const complex<T>&);
+template<class T> complex<T> sqrt (const complex<T>&);
+template<class T> complex<T> tan (const complex<T>&);
+template<class T> complex<T> tanh (const complex<T>&);
+
+template<class T, class charT, class traits>
+  basic_istream<charT, traits>&
+  operator>>(basic_istream<charT, traits>& is, complex<T>& x);
+
+template<class T, class charT, class traits>
+  basic_ostream<charT, traits>&
+  operator<<(basic_ostream<charT, traits>& o, const complex<T>& x);
+
+*/
+
+#include <math.h>
+#include <sstream>
+
+template<class _Tp> class  complex;
+
+template<class _Tp> complex<_Tp> operator*(const complex<_Tp>& __z, const complex<_Tp>& __w);
+template<class _Tp> complex<_Tp> operator/(const complex<_Tp>& __x, const complex<_Tp>& __y);
+
+template<class _Tp>
+class  complex
+{
+public:
+    typedef _Tp value_type;
+private:
+    value_type __re_;
+    value_type __im_;
+public:
+    CUDA_CALLABLE_MEMBER
+    complex(const value_type& __re = value_type(), const value_type& __im = value_type())
+        : __re_(__re), __im_(__im) {}
+    template<class _Xp> CUDA_CALLABLE_MEMBER
+    complex(const complex<_Xp>& __c)
+        : __re_(__c.real()), __im_(__c.imag()) {}
+
+    CUDA_CALLABLE_MEMBER value_type real() const {return __re_;}
+    CUDA_CALLABLE_MEMBER value_type imag() const {return __im_;}
+
+    CUDA_CALLABLE_MEMBER void real(value_type __re) {__re_ = __re;}
+    CUDA_CALLABLE_MEMBER void imag(value_type __im) {__im_ = __im;}
+
+    CUDA_CALLABLE_MEMBER complex& operator= (const value_type& __re)
+        {__re_ = __re; __im_ = value_type(); return *this;}
+    CUDA_CALLABLE_MEMBER complex& operator+=(const value_type& __re) {__re_ += __re; return *this;}
+    CUDA_CALLABLE_MEMBER complex& operator-=(const value_type& __re) {__re_ -= __re; return *this;}
+    CUDA_CALLABLE_MEMBER complex& operator*=(const value_type& __re) {__re_ *= __re; __im_ *= __re; return *this;}
+    CUDA_CALLABLE_MEMBER complex& operator/=(const value_type& __re) {__re_ /= __re; __im_ /= __re; return *this;}
+
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator= (const complex<_Xp>& __c)
+        {
+            __re_ = __c.real();
+            __im_ = __c.imag();
+            return *this;
+        }
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator+=(const complex<_Xp>& __c)
+        {
+            __re_ += __c.real();
+            __im_ += __c.imag();
+            return *this;
+        }
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator-=(const complex<_Xp>& __c)
+        {
+            __re_ -= __c.real();
+            __im_ -= __c.imag();
+            return *this;
+        }
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator*=(const complex<_Xp>& __c)
+        {
+            *this = *this * __c;
+            return *this;
+        }
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator/=(const complex<_Xp>& __c)
+        {
+            *this = *this / __c;
+            return *this;
+        }
+};
+
+template<> class  complex<double>;
+
+template<>
+class  complex<float>
+{
+    float __re_;
+    float __im_;
+public:
+    typedef float value_type;
+
+    /*constexpr*/ CUDA_CALLABLE_MEMBER complex(float __re = 0.0f, float __im = 0.0f)
+        : __re_(__re), __im_(__im) {}
+    explicit /*constexpr*/ complex(const complex<double>& __c);
+
+    /*constexpr*/ CUDA_CALLABLE_MEMBER float real() const {return __re_;}
+    /*constexpr*/ CUDA_CALLABLE_MEMBER float imag() const {return __im_;}
+
+    CUDA_CALLABLE_MEMBER void real(value_type __re) {__re_ = __re;}
+    CUDA_CALLABLE_MEMBER void imag(value_type __im) {__im_ = __im;}
+
+    CUDA_CALLABLE_MEMBER complex& operator= (float __re)
+        {__re_ = __re; __im_ = value_type(); return *this;}
+    CUDA_CALLABLE_MEMBER complex& operator+=(float __re) {__re_ += __re; return *this;}
+    CUDA_CALLABLE_MEMBER complex& operator-=(float __re) {__re_ -= __re; return *this;}
+    CUDA_CALLABLE_MEMBER complex& operator*=(float __re) {__re_ *= __re; __im_ *= __re; return *this;}
+    CUDA_CALLABLE_MEMBER complex& operator/=(float __re) {__re_ /= __re; __im_ /= __re; return *this;}
+
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator= (const complex<_Xp>& __c)
+        {
+            __re_ = __c.real();
+            __im_ = __c.imag();
+            return *this;
+        }
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator+=(const complex<_Xp>& __c)
+        {
+            __re_ += __c.real();
+            __im_ += __c.imag();
+            return *this;
+        }
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator-=(const complex<_Xp>& __c)
+        {
+            __re_ -= __c.real();
+            __im_ -= __c.imag();
+            return *this;
+        }
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator*=(const complex<_Xp>& __c)
+        {
+            *this = *this * __c;
+            return *this;
+        }
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator/=(const complex<_Xp>& __c)
+        {
+            *this = *this / __c;
+            return *this;
+        }
+};
+
+template<>
+class  complex<double>
+{
+    double __re_;
+    double __im_;
+public:
+    typedef double value_type;
+
+    /*constexpr*/ CUDA_CALLABLE_MEMBER complex(double __re = 0.0, double __im = 0.0)
+        : __re_(__re), __im_(__im) {}
+    /*constexpr*/ complex(const complex<float>& __c);
+
+    /*constexpr*/ CUDA_CALLABLE_MEMBER double real() const {return __re_;}
+    /*constexpr*/ CUDA_CALLABLE_MEMBER double imag() const {return __im_;}
+
+    CUDA_CALLABLE_MEMBER void real(value_type __re) {__re_ = __re;}
+    CUDA_CALLABLE_MEMBER void imag(value_type __im) {__im_ = __im;}
+
+    CUDA_CALLABLE_MEMBER complex& operator= (double __re)
+        {__re_ = __re; __im_ = value_type(); return *this;}
+    CUDA_CALLABLE_MEMBER complex& operator+=(double __re) {__re_ += __re; return *this;}
+    CUDA_CALLABLE_MEMBER complex& operator-=(double __re) {__re_ -= __re; return *this;}
+    CUDA_CALLABLE_MEMBER complex& operator*=(double __re) {__re_ *= __re; __im_ *= __re; return *this;}
+    CUDA_CALLABLE_MEMBER complex& operator/=(double __re) {__re_ /= __re; __im_ /= __re; return *this;}
+
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator= (const complex<_Xp>& __c)
+        {
+            __re_ = __c.real();
+            __im_ = __c.imag();
+            return *this;
+        }
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator+=(const complex<_Xp>& __c)
+        {
+            __re_ += __c.real();
+            __im_ += __c.imag();
+            return *this;
+        }
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator-=(const complex<_Xp>& __c)
+        {
+            __re_ -= __c.real();
+            __im_ -= __c.imag();
+            return *this;
+        }
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator*=(const complex<_Xp>& __c)
+        {
+            *this = *this * __c;
+            return *this;
+        }
+    template<class _Xp> CUDA_CALLABLE_MEMBER complex& operator/=(const complex<_Xp>& __c)
+        {
+            *this = *this / __c;
+            return *this;
+        }
+};
+
+//constexpr
+inline CUDA_CALLABLE_MEMBER
+complex<float>::complex(const complex<double>& __c)
+    : __re_(__c.real()), __im_(__c.imag()) {}
+
+//constexpr
+inline CUDA_CALLABLE_MEMBER
+complex<double>::complex(const complex<float>& __c)
+    : __re_(__c.real()), __im_(__c.imag()) {}
+
+// 26.3.6 operators:
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+operator+(const complex<_Tp>& __x, const complex<_Tp>& __y)
+{
+    complex<_Tp> __t(__x);
+    __t += __y;
+    return __t;
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+operator+(const complex<_Tp>& __x, const _Tp& __y)
+{
+    complex<_Tp> __t(__x);
+    __t += __y;
+    return __t;
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+operator+(const _Tp& __x, const complex<_Tp>& __y)
+{
+    complex<_Tp> __t(__y);
+    __t += __x;
+    return __t;
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+operator-(const complex<_Tp>& __x, const complex<_Tp>& __y)
+{
+    complex<_Tp> __t(__x);
+    __t -= __y;
+    return __t;
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+operator-(const complex<_Tp>& __x, const _Tp& __y)
+{
+    complex<_Tp> __t(__x);
+    __t -= __y;
+    return __t;
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+operator-(const _Tp& __x, const complex<_Tp>& __y)
+{
+    complex<_Tp> __t(-__y);
+    __t += __x;
+    return __t;
+}
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+operator*(const complex<_Tp>& __z, const complex<_Tp>& __w)
+{
+    _Tp __a = __z.real();
+    _Tp __b = __z.imag();
+    _Tp __c = __w.real();
+    _Tp __d = __w.imag();
+    _Tp __ac = __a * __c;
+    _Tp __bd = __b * __d;
+    _Tp __ad = __a * __d;
+    _Tp __bc = __b * __c;
+    _Tp __x = __ac - __bd;
+    _Tp __y = __ad + __bc;
+    if (isnan(__x) && isnan(__y))
+    {
+        bool __recalc = false;
+        if (isinf(__a) || isinf(__b))
+        {
+            __a = copysign(isinf(__a) ? _Tp(1) : _Tp(0), __a);
+            __b = copysign(isinf(__b) ? _Tp(1) : _Tp(0), __b);
+            if (isnan(__c))
+                __c = copysign(_Tp(0), __c);
+            if (isnan(__d))
+                __d = copysign(_Tp(0), __d);
+            __recalc = true;
+        }
+        if (isinf(__c) || isinf(__d))
+        {
+            __c = copysign(isinf(__c) ? _Tp(1) : _Tp(0), __c);
+            __d = copysign(isinf(__d) ? _Tp(1) : _Tp(0), __d);
+            if (isnan(__a))
+                __a = copysign(_Tp(0), __a);
+            if (isnan(__b))
+                __b = copysign(_Tp(0), __b);
+            __recalc = true;
+        }
+        if (!__recalc && (isinf(__ac) || isinf(__bd) ||
+                          isinf(__ad) || isinf(__bc)))
+        {
+            if (isnan(__a))
+                __a = copysign(_Tp(0), __a);
+            if (isnan(__b))
+                __b = copysign(_Tp(0), __b);
+            if (isnan(__c))
+                __c = copysign(_Tp(0), __c);
+            if (isnan(__d))
+                __d = copysign(_Tp(0), __d);
+            __recalc = true;
+        }
+        if (__recalc)
+        {
+            __x = _Tp(INFINITY) * (__a * __c - __b * __d);
+            __y = _Tp(INFINITY) * (__a * __d + __b * __c);
+        }
+    }
+    return complex<_Tp>(__x, __y);
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+operator*(const complex<_Tp>& __x, const _Tp& __y)
+{
+    complex<_Tp> __t(__x);
+    __t *= __y;
+    return __t;
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+operator*(const _Tp& __x, const complex<_Tp>& __y)
+{
+    complex<_Tp> __t(__y);
+    __t *= __x;
+    return __t;
+}
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+operator/(const complex<_Tp>& __z, const complex<_Tp>& __w)
+{
+    int __ilogbw = 0;
+    _Tp __a = __z.real();
+    _Tp __b = __z.imag();
+    _Tp __c = __w.real();
+    _Tp __d = __w.imag();
+    _Tp __logbw = logb(fmax(fabs(__c), fabs(__d)));
+    if (isfinite(__logbw))
+    {
+        __ilogbw = static_cast<int>(__logbw);
+        __c = scalbn(__c, -__ilogbw);
+        __d = scalbn(__d, -__ilogbw);
+    }
+    _Tp __denom = __c * __c + __d * __d;
+    _Tp __x = scalbn((__a * __c + __b * __d) / __denom, -__ilogbw);
+    _Tp __y = scalbn((__b * __c - __a * __d) / __denom, -__ilogbw);
+    if (isnan(__x) && isnan(__y))
+    {
+        if ((__denom == _Tp(0)) && (!isnan(__a) || !isnan(__b)))
+        {
+            __x = copysign(_Tp(INFINITY), __c) * __a;
+            __y = copysign(_Tp(INFINITY), __c) * __b;
+        }
+        else if ((isinf(__a) || isinf(__b)) && isfinite(__c) && isfinite(__d))
+        {
+            __a = copysign(isinf(__a) ? _Tp(1) : _Tp(0), __a);
+            __b = copysign(isinf(__b) ? _Tp(1) : _Tp(0), __b);
+            __x = _Tp(INFINITY) * (__a * __c + __b * __d);
+            __y = _Tp(INFINITY) * (__b * __c - __a * __d);
+        }
+        else if (isinf(__logbw) && __logbw > _Tp(0) && isfinite(__a) && isfinite(__b))
+        {
+            __c = copysign(isinf(__c) ? _Tp(1) : _Tp(0), __c);
+            __d = copysign(isinf(__d) ? _Tp(1) : _Tp(0), __d);
+            __x = _Tp(0) * (__a * __c + __b * __d);
+            __y = _Tp(0) * (__b * __c - __a * __d);
+        }
+    }
+    return complex<_Tp>(__x, __y);
+}
+
+template<>
+CUDA_CALLABLE_MEMBER
+complex<float>
+operator/(const complex<float>& __z, const complex<float>& __w)
+{
+    int __ilogbw = 0;
+    float __a = __z.real();
+    float __b = __z.imag();
+    float __c = __w.real();
+    float __d = __w.imag();
+    float __logbw = logbf(fmaxf(fabsf(__c), fabsf(__d)));
+    if (isfinite(__logbw))
+    {
+        __ilogbw = static_cast<int>(__logbw);
+        __c = scalbnf(__c, -__ilogbw);
+        __d = scalbnf(__d, -__ilogbw);
+    }
+    float __denom = __c * __c + __d * __d;
+    float __x = scalbnf((__a * __c + __b * __d) / __denom, -__ilogbw);
+    float __y = scalbnf((__b * __c - __a * __d) / __denom, -__ilogbw);
+    if (isnan(__x) && isnan(__y))
+    {
+        if ((__denom == float(0)) && (!isnan(__a) || !isnan(__b)))
+        {
+#pragma warning(suppress: 4756) // Ignore INFINITY related warning
+            __x = copysignf(INFINITY, __c) * __a;
+#pragma warning(suppress: 4756) // Ignore INFINITY related warning
+            __y = copysignf(INFINITY, __c) * __b;
+        }
+        else if ((isinf(__a) || isinf(__b)) && isfinite(__c) && isfinite(__d))
+        {
+            __a = copysignf(isinf(__a) ? float(1) : float(0), __a);
+            __b = copysignf(isinf(__b) ? float(1) : float(0), __b);
+#pragma warning(suppress: 4756) // Ignore INFINITY related warning
+            __x = INFINITY * (__a * __c + __b * __d);
+#pragma warning(suppress: 4756) // Ignore INFINITY related warning
+            __y = INFINITY * (__b * __c - __a * __d);
+        }
+        else if (isinf(__logbw) && __logbw > float(0) && isfinite(__a) && isfinite(__b))
+        {
+            __c = copysignf(isinf(__c) ? float(1) : float(0), __c);
+            __d = copysignf(isinf(__d) ? float(1) : float(0), __d);
+            __x = float(0) * (__a * __c + __b * __d);
+            __y = float(0) * (__b * __c - __a * __d);
+        }
+    }
+    return complex<float>(__x, __y);
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+operator/(const complex<_Tp>& __x, const _Tp& __y)
+{
+    return complex<_Tp>(__x.real() / __y, __x.imag() / __y);
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+operator/(const _Tp& __x, const complex<_Tp>& __y)
+{
+    complex<_Tp> __t(__x);
+    __t /= __y;
+    return __t;
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+operator+(const complex<_Tp>& __x)
+{
+    return __x;
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+operator-(const complex<_Tp>& __x)
+{
+    return complex<_Tp>(-__x.real(), -__x.imag());
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+bool
+operator==(const complex<_Tp>& __x, const complex<_Tp>& __y)
+{
+    return __x.real() == __y.real() && __x.imag() == __y.imag();
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+bool
+operator==(const complex<_Tp>& __x, const _Tp& __y)
+{
+    return __x.real() == __y && __x.imag() == 0;
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+bool
+operator==(const _Tp& __x, const complex<_Tp>& __y)
+{
+    return __x == __y.real() && 0 == __y.imag();
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+bool
+operator!=(const complex<_Tp>& __x, const complex<_Tp>& __y)
+{
+    return !(__x == __y);
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+bool
+operator!=(const complex<_Tp>& __x, const _Tp& __y)
+{
+    return !(__x == __y);
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+bool
+operator!=(const _Tp& __x, const complex<_Tp>& __y)
+{
+    return !(__x == __y);
+}
+
+// 26.3.7 values:
+
+// real
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+_Tp
+real(const complex<_Tp>& __c)
+{
+    return __c.real();
+}
+
+inline CUDA_CALLABLE_MEMBER
+double
+real(double __re)
+{
+    return __re;
+}
+
+inline CUDA_CALLABLE_MEMBER
+float
+real(float  __re)
+{
+    return __re;
+}
+
+// imag
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+_Tp
+imag(const complex<_Tp>& __c)
+{
+    return __c.imag();
+}
+
+inline CUDA_CALLABLE_MEMBER
+double
+imag(double __re)
+{
+    return 0;
+}
+
+inline CUDA_CALLABLE_MEMBER
+float
+imag(float  __re)
+{
+    return 0;
+}
+
+// abs
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+_Tp
+abs(const complex<_Tp>& __c)
+{
+    return hypot(__c.real(), __c.imag());
+}
+
+// arg
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+_Tp
+arg(const complex<_Tp>& __c)
+{
+    return atan2(__c.imag(), __c.real());
+}
+
+inline CUDA_CALLABLE_MEMBER
+double
+arg(double __re)
+{
+    return atan2(0., __re);
+}
+
+inline CUDA_CALLABLE_MEMBER
+float
+arg(float __re)
+{
+    return atan2f(0.F, __re);
+}
+
+// norm
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+_Tp
+norm(const complex<_Tp>& __c)
+{
+    if (isinf(__c.real()))
+        return fabs(__c.real());
+    if (isinf(__c.imag()))
+        return fabs(__c.imag());
+    return __c.real() * __c.real() + __c.imag() * __c.imag();
+}
+
+inline CUDA_CALLABLE_MEMBER
+double
+norm(double __re)
+{
+    return __re * __re;
+}
+
+inline CUDA_CALLABLE_MEMBER
+float
+norm(float __re)
+{
+    return __re * __re;
+}
+
+// conj
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+conj(const complex<_Tp>& __c)
+{
+    return complex<_Tp>(__c.real(), -__c.imag());
+}
+
+inline CUDA_CALLABLE_MEMBER
+complex<double>
+conj(double __re)
+{
+    return complex<double>(__re);
+}
+
+inline CUDA_CALLABLE_MEMBER
+complex<float>
+conj(float __re)
+{
+    return complex<float>(__re);
+}
+
+// proj
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+proj(const complex<_Tp>& __c)
+{
+    complex<_Tp> __r = __c;
+    if (isinf(__c.real()) || isinf(__c.imag()))
+        __r = complex<_Tp>(INFINITY, copysign(_Tp(0), __c.imag()));
+    return __r;
+}
+
+inline CUDA_CALLABLE_MEMBER
+complex<double>
+proj(double __re)
+{
+    if (isinf(__re))
+        __re = fabs(__re);
+    return complex<double>(__re);
+}
+
+inline CUDA_CALLABLE_MEMBER
+complex<float>
+proj(float __re)
+{
+    if (isinf(__re))
+        __re = fabs(__re);
+    return complex<float>(__re);
+}
+
+// polar
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+polar(const _Tp& __rho, const _Tp& __theta = _Tp(0))
+{
+    if (isnan(__rho) || signbit(__rho))
+        return complex<_Tp>(_Tp(NAN), _Tp(NAN));
+    if (isnan(__theta))
+    {
+        if (isinf(__rho))
+            return complex<_Tp>(__rho, __theta);
+        return complex<_Tp>(__theta, __theta);
+    }
+    if (isinf(__theta))
+    {
+        if (isinf(__rho))
+            return complex<_Tp>(__rho, _Tp(NAN));
+        return complex<_Tp>(_Tp(NAN), _Tp(NAN));
+    }
+    _Tp __x = __rho * cos(__theta);
+    if (isnan(__x))
+        __x = 0;
+    _Tp __y = __rho * sin(__theta);
+    if (isnan(__y))
+        __y = 0;
+    return complex<_Tp>(__x, __y);
+}
+
+// log
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+log(const complex<_Tp>& __x)
+{
+    return complex<_Tp>(log(abs(__x)), arg(__x));
+}
+
+// log10
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+log10(const complex<_Tp>& __x)
+{
+    return log(__x) / log(_Tp(10));
+}
+
+// sqrt
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+sqrt(const complex<_Tp>& __x)
+{
+    if (isinf(__x.imag()))
+        return complex<_Tp>(_Tp(INFINITY), __x.imag());
+    if (isinf(__x.real()))
+    {
+        if (__x.real() > _Tp(0))
+            return complex<_Tp>(__x.real(), isnan(__x.imag()) ? __x.imag() : copysign(_Tp(0), __x.imag()));
+        return complex<_Tp>(isnan(__x.imag()) ? __x.imag() : _Tp(0), copysign(__x.real(), __x.imag()));
+    }
+    return polar(sqrt(abs(__x)), arg(__x) / _Tp(2));
+}
+
+// exp
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+exp(const complex<_Tp>& __x)
+{
+    _Tp __i = __x.imag();
+    if (isinf(__x.real()))
+    {
+        if (__x.real() < _Tp(0))
+        {
+            if (!isfinite(__i))
+                __i = _Tp(1);
+        }
+        else if (__i == 0 || !isfinite(__i))
+        {
+            if (isinf(__i))
+                __i = _Tp(NAN);
+            return complex<_Tp>(__x.real(), __i);
+        }
+    }
+    else if (isnan(__x.real()) && __x.imag() == 0)
+        return __x;
+    _Tp __e = exp(__x.real());
+    return complex<_Tp>(__e * cos(__i), __e * sin(__i));
+}
+
+// pow
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+pow(const complex<_Tp>& __x, const complex<_Tp>& __y)
+{
+    return exp(__y * log(__x));
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+pow(const complex<_Tp>& __x, const _Tp& __y)
+{   
+    return pow(__x, complex<_Tp>(__y));
+}
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+pow(const _Tp& __x, const complex<_Tp>& __y)
+{
+    return pow(complex<_Tp>(__x), __y);
+}
+
+// asinh
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+asinh(const complex<_Tp>& __x)
+{
+    const _Tp __pi(atan2(+0., -0.));
+    if (isinf(__x.real()))
+    {
+        if (isnan(__x.imag()))
+            return __x;
+        if (isinf(__x.imag()))
+            return complex<_Tp>(__x.real(), copysign(__pi * _Tp(0.25), __x.imag()));
+        return complex<_Tp>(__x.real(), copysign(_Tp(0), __x.imag()));
+    }
+    if (isnan(__x.real()))
+    {
+        if (isinf(__x.imag()))
+            return complex<_Tp>(__x.imag(), __x.real());
+        if (__x.imag() == 0)
+            return __x;
+        return complex<_Tp>(__x.real(), __x.real());
+    }
+    if (isinf(__x.imag()))
+        return complex<_Tp>(copysign(__x.imag(), __x.real()), copysign(__pi/_Tp(2), __x.imag()));
+    complex<_Tp> __z = log(__x + sqrt(pow(__x, _Tp(2)) + _Tp(1)));
+    return complex<_Tp>(copysign(__z.real(), __x.real()), copysign(__z.imag(), __x.imag()));
+}
+
+// acosh
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+acosh(const complex<_Tp>& __x)
+{
+    const _Tp __pi(atan2(+0., -0.));
+    if (isinf(__x.real()))
+    {
+        if (isnan(__x.imag()))
+            return complex<_Tp>(fabs(__x.real()), __x.imag());
+        if (isinf(__x.imag()))
+            if (__x.real() > 0)
+                return complex<_Tp>(__x.real(), copysign(__pi * _Tp(0.25), __x.imag()));
+            else
+                return complex<_Tp>(-__x.real(), copysign(__pi * _Tp(0.75), __x.imag()));
+        if (__x.real() < 0)
+            return complex<_Tp>(-__x.real(), copysign(__pi, __x.imag()));
+        return complex<_Tp>(__x.real(), copysign(_Tp(0), __x.imag()));
+    }
+    if (isnan(__x.real()))
+    {
+        if (isinf(__x.imag()))
+            return complex<_Tp>(fabs(__x.imag()), __x.real());
+        return complex<_Tp>(__x.real(), __x.real());
+    }
+    if (isinf(__x.imag()))
+        return complex<_Tp>(fabs(__x.imag()), copysign(__pi/_Tp(2), __x.imag()));
+    complex<_Tp> __z = log(__x + sqrt(pow(__x, _Tp(2)) - _Tp(1)));
+    return complex<_Tp>(copysign(__z.real(), _Tp(0)), copysign(__z.imag(), __x.imag()));
+}
+
+// atanh
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+atanh(const complex<_Tp>& __x)
+{
+    const _Tp __pi(atan2(+0., -0.));
+    if (isinf(__x.imag()))
+    {
+        return complex<_Tp>(copysign(_Tp(0), __x.real()), copysign(__pi/_Tp(2), __x.imag()));
+    }
+    if (isnan(__x.imag()))
+    {
+        if (isinf(__x.real()) || __x.real() == 0)
+            return complex<_Tp>(copysign(_Tp(0), __x.real()), __x.imag());
+        return complex<_Tp>(__x.imag(), __x.imag());
+    }
+    if (isnan(__x.real()))
+    {
+        return complex<_Tp>(__x.real(), __x.real());
+    }
+    if (isinf(__x.real()))
+    {
+        return complex<_Tp>(copysign(_Tp(0), __x.real()), copysign(__pi/_Tp(2), __x.imag()));
+    }
+    if (fabs(__x.real()) == _Tp(1) && __x.imag() == _Tp(0))
+    {
+        return complex<_Tp>(copysign(_Tp(INFINITY), __x.real()), copysign(_Tp(0), __x.imag()));
+    }
+    complex<_Tp> __z = log((_Tp(1) + __x) / (_Tp(1) - __x)) / _Tp(2);
+    return complex<_Tp>(copysign(__z.real(), __x.real()), copysign(__z.imag(), __x.imag()));
+}
+
+// sinh
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+sinh(const complex<_Tp>& __x)
+{
+    if (isinf(__x.real()) && !isfinite(__x.imag()))
+        return complex<_Tp>(__x.real(), _Tp(NAN));
+    if (__x.real() == 0 && !isfinite(__x.imag()))
+        return complex<_Tp>(__x.real(), _Tp(NAN));
+    if (__x.imag() == 0 && !isfinite(__x.real()))
+        return __x;
+    return complex<_Tp>(sinh(__x.real()) * cos(__x.imag()), cosh(__x.real()) * sin(__x.imag()));
+}
+
+// cosh
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+cosh(const complex<_Tp>& __x)
+{
+    if (isinf(__x.real()) && !isfinite(__x.imag()))
+        return complex<_Tp>(fabs(__x.real()), _Tp(NAN));
+    if (__x.real() == 0 && !isfinite(__x.imag()))
+        return complex<_Tp>(_Tp(NAN), __x.real());
+    if (__x.real() == 0 && __x.imag() == 0)
+        return complex<_Tp>(_Tp(1), __x.imag());
+    if (__x.imag() == 0 && !isfinite(__x.real()))
+        return complex<_Tp>(fabs(__x.real()), __x.imag());
+    return complex<_Tp>(cosh(__x.real()) * cos(__x.imag()), sinh(__x.real()) * sin(__x.imag()));
+}
+
+// tanh
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+tanh(const complex<_Tp>& __x)
+{
+    if (isinf(__x.real()))
+    {
+        if (!isfinite(__x.imag()))
+            return complex<_Tp>(_Tp(1), _Tp(0));
+        return complex<_Tp>(_Tp(1), copysign(_Tp(0), sin(_Tp(2) * __x.imag())));
+    }
+    if (isnan(__x.real()) && __x.imag() == 0)
+        return __x;
+    _Tp __2r(_Tp(2) * __x.real());
+    _Tp __2i(_Tp(2) * __x.imag());
+    _Tp __d(cosh(__2r) + cos(__2i));
+    return  complex<_Tp>(sinh(__2r)/__d, sin(__2i)/__d);
+}
+
+// asin
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+asin(const complex<_Tp>& __x)
+{
+    complex<_Tp> __z = asinh(complex<_Tp>(-__x.imag(), __x.real()));
+    return complex<_Tp>(__z.imag(), -__z.real());
+}
+
+// acos
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+acos(const complex<_Tp>& __x)
+{
+    const _Tp __pi(atan2(+0., -0.));
+    if (isinf(__x.real()))
+    {
+        if (isnan(__x.imag()))
+            return complex<_Tp>(__x.imag(), __x.real());
+        if (isinf(__x.imag()))
+        {
+            if (__x.real() < _Tp(0))
+                return complex<_Tp>(_Tp(0.75) * __pi, -__x.imag());
+            return complex<_Tp>(_Tp(0.25) * __pi, -__x.imag());
+        }
+        if (__x.real() < _Tp(0))
+            return complex<_Tp>(__pi, signbit(__x.imag()) ? -__x.real() : __x.real());
+        return complex<_Tp>(_Tp(0), signbit(__x.imag()) ? __x.real() : -__x.real());
+    }
+    if (isnan(__x.real()))
+    {
+        if (isinf(__x.imag()))
+            return complex<_Tp>(__x.real(), -__x.imag());
+        return complex<_Tp>(__x.real(), __x.real());
+    }
+    if (isinf(__x.imag()))
+        return complex<_Tp>(__pi/_Tp(2), -__x.imag());
+    if (__x.real() == 0)
+        return complex<_Tp>(__pi/_Tp(2), -__x.imag());
+    complex<_Tp> __z = log(__x + sqrt(pow(__x, _Tp(2)) - _Tp(1)));
+    if (signbit(__x.imag()))
+        return complex<_Tp>(fabs(__z.imag()), fabs(__z.real()));
+    return complex<_Tp>(fabs(__z.imag()), -fabs(__z.real()));
+}
+
+// atan
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+atan(const complex<_Tp>& __x)
+{
+    complex<_Tp> __z = atanh(complex<_Tp>(-__x.imag(), __x.real()));
+    return complex<_Tp>(__z.imag(), -__z.real());
+}
+
+// sin
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+sin(const complex<_Tp>& __x)
+{
+    complex<_Tp> __z = sinh(complex<_Tp>(-__x.imag(), __x.real()));
+    return complex<_Tp>(__z.imag(), -__z.real());
+}
+
+// cos
+
+template<class _Tp>
+inline CUDA_CALLABLE_MEMBER
+complex<_Tp>
+cos(const complex<_Tp>& __x)
+{
+    return cosh(complex<_Tp>(-__x.imag(), __x.real()));
+}
+
+// tan
+
+template<class _Tp>
+CUDA_CALLABLE_MEMBER
+complex<_Tp>
+tan(const complex<_Tp>& __x)
+{
+    complex<_Tp> __z = tanh(complex<_Tp>(-__x.imag(), __x.real()));
+    return complex<_Tp>(__z.imag(), -__z.real());
+}
+
+template<class _Tp, class _CharT, class _Traits>
+std::basic_istream<_CharT, _Traits>&
+operator>>(std::basic_istream<_CharT, _Traits>& __is, complex<_Tp>& __x)
+{
+    if (__is.good())
+    {
+        ws(__is);
+        if (__is.peek() == _CharT('('))
+        {
+            __is.get();
+            _Tp __r;
+            __is >> __r;
+            if (!__is.fail())
+            {
+                ws(__is);
+                _CharT __c = __is.peek();
+                if (__c == _CharT(','))
+                {
+                    __is.get();
+                    _Tp __i;
+                    __is >> __i;
+                    if (!__is.fail())
+                    {
+                        ws(__is);
+                        __c = __is.peek();
+                        if (__c == _CharT(')'))
+                        {
+                            __is.get();
+                            __x = complex<_Tp>(__r, __i);
+                        }
+                        else
+                            __is.setstate(std::ios_base::failbit);
+                    }
+                    else
+                        __is.setstate(std::ios_base::failbit);
+                }
+                else if (__c == _CharT(')'))
+                {
+                    __is.get();
+                    __x = complex<_Tp>(__r, _Tp(0));
+                }
+                else
+                    __is.setstate(std::ios_base::failbit);
+            }
+            else
+                __is.setstate(std::ios_base::failbit);
+        }
+        else
+        {
+            _Tp __r;
+            __is >> __r;
+            if (!__is.fail())
+                __x = complex<_Tp>(__r, _Tp(0));
+            else
+                __is.setstate(std::ios_base::failbit);
+        }
+    }
+    else
+        __is.setstate(std::ios_base::failbit);
+    return __is;
+}
+
+template<class _Tp, class _CharT, class _Traits>
+std::basic_ostream<_CharT, _Traits>&
+operator<<(std::basic_ostream<_CharT, _Traits>& __os, const complex<_Tp>& __x)
+{
+    std::basic_ostringstream<_CharT, _Traits> __s;
+    __s.flags(__os.flags());
+    __s.imbue(__os.getloc());
+    __s.precision(__os.precision());
+    __s << '(' << __x.real() << ',' << __x.imag() << ')';
+    return __os << __s.str();
+}
+
+//} // close namespace cuda_complex
+
+#endif  // CUDA_COMPLEX_HPP

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,7 +23,7 @@ Installation
 
 Install from PyPI::
 
-  pip install fsph
+  pip install --no-build-isolation fsph
 
 Or from source::
 
@@ -36,6 +36,23 @@ API Reference
 
 .. automodule:: fsph
    :members: pointwise_sph, get_LMs
+
+Tensorflow Operations
+---------------------
+
+As of version 0.2, fsph can also compute spherical harmonic series of
+points on the CPU and GPU using tensorflow. This module is
+automatically built when tensorflow is found while installing
+fsph. GPU support is enabled when CUDA (specifically, the `nvcc`
+binary) is found while installing fsph.
+
+.. py:function:: fsph.tf_ops.spherical_harmonic_series(inputs, lmax, negative_m)
+
+   Compute a spherical harmonic series for a set of input points.
+
+   :param inputs: (..., 2) array of (phi, theta) values
+   :param lmax: Maximum spherical harmonic l to compute
+   :param negative_m: If True, compute for negative as well as positive m values
 
 Indices and tables
 ==================

--- a/fsph/_fsph.pyx
+++ b/fsph/_fsph.pyx
@@ -25,7 +25,7 @@ def pointwise_sph(phi, theta, lmax, negative_m=True):
     To map the columns of the result array to particular (l, m)
     values, see :py:func:`get_LMs`.
 
-    :param phi: Array-like object of polar angles in [-pi, pi]
+    :param phi: Array-like object of polar angles in [0, pi]
     :param theta: Array-like object of azimuthal angles in [0, 2*pi]
     :param lmax: Integer maximum spherical harmonic degree to compute (inclusive)
     :param negative_m: Set to False to disable the negative-m spherical harmonics

--- a/fsph/tf_ops.py
+++ b/fsph/tf_ops.py
@@ -1,0 +1,27 @@
+
+import tensorflow as tf
+from tensorflow.python.framework import ops
+
+from . import _fsph
+so_name = _fsph.__file__.replace('/_fsph.', '/_tf_ops.')
+
+all_ops = tf.load_op_library(so_name)
+
+spherical_harmonic_series = all_ops.spherical_harmonic_series
+spherical_harmonic_series_grad = all_ops.spherical_harmonic_series_grad
+
+@ops.RegisterGradient('SphericalHarmonicSeries')
+def _spherical_harmonic_series_grad(op, grad):
+    # input_grad:: (..., Nsphs, 2)
+    input_grad = spherical_harmonic_series_grad(*op.inputs)
+
+    # grad:: (..., Nsphs) -> (..., Nsphs, 1)
+    grad = tf.expand_dims(grad, -1)
+
+    # result::(..., 2, 1)
+    result = (tf.linalg.matmul(tf.math.conj(input_grad), grad, transpose_a=True) +
+              tf.linalg.matmul(input_grad, tf.math.conj(grad), transpose_a=True))
+    # result -> (..., 2)
+    result = tf.math.real(tf.squeeze(result, -1))*0.5
+
+    return [result, None, None]

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python
 
-import os, subprocess, sys
+import distutils
+from distutils.dep_util import newer
 from distutils.command.build_ext import build_ext
 from distutils.core import Extension, setup
+from distutils import log
+import os
+import shutil
+import subprocess
+import sys
 import numpy
 
 with open('fsph/version.py') as version_file:
@@ -12,9 +18,11 @@ macros = []
 extra_args = []
 sources = []
 
+CYTHONIZE = False
 if '--cython' in sys.argv:
     from Cython.Build import cythonize
     sys.argv.remove('--cython')
+    CYTHONIZE = True
 
     def myCythonize(macros, *args, **kwargs):
         result = cythonize(*args, **kwargs)
@@ -34,6 +42,72 @@ else:
                          define_macros=macros, extra_compile_args=extra_args,
                          extra_link_args=extra_args, include_dirs=[numpy.get_include()])]
 
+class CustomBuildCommand(build_ext):
+    """Custom build command that compiles the CUDA tensorflow module and incorporates it into the final extension.
+
+    Also compiles with -O0 if debug is enabled. Aside from that, this
+    command should not change default behavior if tensorflow is not
+    enabled or nvcc is not found. The nvcc binary can be set via the
+    NVCC environment variable.
+
+    If enabling cuda is undesirable but would otherwise be enabled by
+    default, set the NVCC environment variable to a name that does not
+    exist on $PATH.
+    """
+    def run(self, *args, **kwargs):
+        NVCC = os.environ.get('NVCC', 'nvcc')
+        nvcc_path = distutils.spawn.find_executable(NVCC)
+        found_nvcc = nvcc_path is not None
+        log.info('NVCC: {}'.format(nvcc_path))
+
+        for ext in self.extensions:
+
+            if self.debug:
+                ext.extra_compile_args.append('-O0')
+
+            if '_tf_ops' in ext.name and found_nvcc:
+                src_name = 'src/tensorflow_op_gpu.cu'
+                output_location = os.path.join(self.build_temp, 'tensorflow_op_gpu.cu.o')
+
+                ext.sources.append('src/tensorflow_op_gpu.cpp')
+
+                library_dir = os.path.join(os.path.split(nvcc_path)[0], '..', 'lib')
+                ext.library_dirs.append(library_dir)
+                ext.libraries.append('cudart')
+
+                if newer(src_name, output_location):
+                    os.makedirs(self.build_temp, 0o755, exist_ok=True)
+                    command = [NVCC, '-c', '-o', output_location, src_name,
+                               '-D', 'GOOGLE_CUDA=1', '-Xcompiler', '-fPIC']
+                    command.extend(ext.extra_compile_args)
+
+                    if self.verbose:
+                        command.append('--resource-usage')
+
+                    if self.debug:
+                        command.extend(['-g', '-G'])
+
+                    log.info(' '.join(command))
+                    subprocess.check_call(command)
+
+                    ext.extra_objects.append(output_location)
+
+        super().run(*args, **kwargs)
+
+try:
+    import tensorflow as tf
+
+    ext = Extension('fsph._tf_ops',
+                    sources=['src/tensorflow_op.cpp'],
+                    extra_compile_args=tf.sysconfig.get_compile_flags(),
+                    extra_link_args=tf.sysconfig.get_link_flags())
+    modules.append(ext)
+    log.info('Will build tensorflow op library')
+except ImportError:
+    # skip building tensorflow component
+    log.info('Failed importing tensorflow, will not build tensorflow op library')
+    pass
+
 setup(name='fsph',
       version=__version__,
       description='Fast sequential spherical harmonics calculation',
@@ -46,6 +120,12 @@ setup(name='fsph',
           'Programming Language :: Python :: 3',
           'Topic :: Scientific/Engineering :: Mathematics',
       ],
+      cmdclass={
+          'build_ext': CustomBuildCommand,
+      },
+      extras_require={
+          'tensorflow': ['tensorflow'],
+      },
       ext_modules=modules,
       install_requires=['numpy'],
       packages=['fsph'],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('fsph/version.py') as version_file:
     exec(version_file.read())
 
 macros = []
-extra_args = []
+extra_args = ['-std=c++11']
 sources = []
 
 CYTHONIZE = False
@@ -62,6 +62,7 @@ class CustomBuildCommand(build_ext):
 
         for ext in self.extensions:
 
+            ext.extra_compile_args.extend(extra_args)
             if self.debug:
                 ext.extra_compile_args.append('-O0')
 

--- a/src/SharedArray.hpp
+++ b/src/SharedArray.hpp
@@ -131,6 +131,15 @@ public:
             return NULL;
     }
 
+    /// Returns the raw pointer held (NULL otherwise)
+    const T *get() const
+    {
+        if(m_shim)
+            return m_shim->m_target;
+        else
+            return NULL;
+    }
+
     /// Returns the size, in number of objects, of this array
     size_t size() const
     {

--- a/src/internal.hpp
+++ b/src/internal.hpp
@@ -1,0 +1,127 @@
+
+#ifndef __FSPH_INTERNAL__
+#define __FSPH_INTERNAL__
+
+#ifndef __NVCC__
+#define __device__
+#define __host__
+#endif
+
+namespace fsph{
+    namespace internal{
+
+        template<typename Real, typename Complex>
+        class SPHSeriesEvaluator
+        {
+        public:
+            __device__ SPHSeriesEvaluator(const unsigned int &m, const Real &cphi,
+                                          const Real &sphi, const Real &theta,
+                                          bool compute_gradient)
+            {
+                reset(m, cphi, sphi, theta, compute_gradient);
+            }
+
+            __device__ void reset(const unsigned int &m, const Real &cphi,
+                                  const Real &sphi, const Real &theta,
+                                  bool compute_gradient)
+            {
+                m_m = m;
+                m_jacobi_before_last = 0;
+
+                m_last_jacobi = 1.0;
+                for(unsigned int i(1); i <= m; i++)
+                    m_last_jacobi *= 1 + 0.5/i;
+                m_last_jacobi = sqrt(0.5*m_last_jacobi);
+
+                m_Ylm_prefactor = (Complex(pow(sphi, m_m)/sqrt(2*M_PI))*
+                                   exp(Complex(0, m_m*theta)));
+                m_negative_m_prefactor = exp(Complex(0, -2.0*m_m*theta));
+                m_cphi = cphi;
+
+                if(compute_gradient)
+                {
+                    m_gradphi_theta_rotation = exp(Complex(0, -theta));
+                    m_cotphi = cphi/sphi;
+
+                    // disregard gradient when phi == 0, for example
+                    if(!isfinite(m_cotphi))
+                        m_cotphi = 0;
+                }
+            }
+
+            // NOTE: l *must* be incremented afterward to keep a proper series
+            __device__ Complex get(const unsigned int &l)
+            {
+                const Real k(l - m_m);
+                const Real prefactor_1(
+                    2*sqrt((1.0 + (m_m - 0.5)/k)*(1.0 - (m_m - 0.5)/(k + 2.0*m_m))));
+                const Real prefactor_2(
+                    sqrt((1.0 + 4.0/(2.0*k + 2.0*m_m - 3.0))*(1.0 - 1.0/k)*(1.0 - 1.0/(k + 2.0*m_m))));
+                const Real jacobi(
+                    prefactor_1*m_cphi*m_last_jacobi - prefactor_2*m_jacobi_before_last);
+
+                Complex Ylm(m_Ylm_prefactor);
+
+                if(l > m_m)
+                {
+                    Ylm *= jacobi;
+                    m_jacobi_before_last = m_last_jacobi;
+                    m_last_jacobi = jacobi;
+                }
+                else
+                    Ylm *= m_last_jacobi;
+
+                return Ylm;
+            }
+
+            __device__ Complex get_negative_m(const Complex &Ylm) const
+            {
+                return m_negative_m_prefactor*Ylm;
+            }
+
+            __device__ Complex grad_phi(
+                const unsigned int &l, const Complex &Ylm, const Complex &Ylmp1,
+                const bool &negative_m) const
+            {
+                const int m(negative_m? -m_m: m_m);
+                Complex result(m*m_cotphi, 0);
+
+                result *= Ylm;
+
+                if(m_m != l)
+                {
+                    Complex additional(sqrt((Real) (l - m)*(l + m + 1)), 0);
+                    additional *= m_gradphi_theta_rotation;
+                    additional *= Ylmp1;
+
+                    if(!negative_m)
+                        additional *= -1;
+
+                    result += additional;
+                }
+                else if(negative_m)
+                    result *= -1;
+
+                return result;
+            }
+
+            __device__ Complex grad_theta(const Complex &Ylm, const bool &negative_m) const
+            {
+                const int m(negative_m? -m_m: m_m);
+                return Complex(0, m)*Ylm;
+            }
+
+        private:
+            unsigned int m_m;
+            Real m_last_jacobi;
+            Real m_jacobi_before_last;
+            Real m_cphi;
+            Real m_cotphi;
+            Complex m_Ylm_prefactor;
+            Complex m_negative_m_prefactor;
+            Complex m_gradphi_theta_rotation;
+        };
+    }
+}
+
+#endif

--- a/src/spherical_harmonics.hpp
+++ b/src/spherical_harmonics.hpp
@@ -1,9 +1,7 @@
 #include <iostream>
 #include <complex>
 #include <math.h>
-#include <vector>
 #include "SharedArray.hpp"
-#include "internal.hpp"
 
 #ifndef __FSPH_SPHERICAL_HARMONICS__
 #define __FSPH_SPHERICAL_HARMONICS__
@@ -41,21 +39,15 @@ namespace fsph{
         public:
             iterator(const PointSPHEvaluator &generator, bool full_m):
                 m_generator(generator), m_l(0), m_m(0), m_full_m(full_m)
-            {
-                setup(0, 0);
-            }
+            {}
 
             iterator(const iterator &rhs):
-                m_generator(rhs.m_generator), m_l(0), m_m(0), m_full_m(rhs.m_full_m)
-            {
-                setup(rhs.m_l, rhs.m_m);
-            }
+                m_generator(rhs.m_generator), m_l(rhs.m_l), m_m(rhs.m_m), m_full_m(rhs.m_full_m)
+            {}
 
             iterator(const PointSPHEvaluator &generator, unsigned int l, unsigned int m, bool full_m):
-                m_generator(generator), m_l(0), m_m(0), m_full_m(full_m)
-            {
-                setup(l, m);
-            }
+                m_generator(generator), m_l(l), m_m(m), m_full_m(full_m)
+            {}
 
             inline bool operator==(const iterator &rhs) const
             {
@@ -80,52 +72,77 @@ namespace fsph{
                 m_m %= mCount;
                 m_l += deltaL;
 
-                if(deltaL && m_l <= m_generator.m_lmax)
-                {
-                    for(unsigned int m(0); m <= m_l; ++m)
-                    {
-                        const std::complex<Real> Ylm(m_evaluators[m].get(m_l));
-                        m_cached_Ylm[m] = Ylm;
-
-                        if(m_full_m)
-                            m_cached_Ylm[m + m_l] = m_evaluators[m].get_negative_m(
-                                Ylm);
-                    }
-
-                }
-
                 return *this;
             }
 
             inline std::complex<Real> operator*() const
             {
-                return m_cached_Ylm[m_m];
+                // give negative m result
+                if(m_m > m_l)
+                {
+                    const unsigned int m(m_m - m_l);
+                    return (std::complex<Real>(m_generator.m_legendre[sphIndex(m_l, m)]/sqrt(2*M_PI))*
+                            std::conj(m_generator.m_thetaHarmonics[m]));
+                }
+                else // positive m
+                {
+                    return (std::complex<Real>(
+                                m_generator.m_legendre[sphIndex(m_l, m_m)]/sqrt(2*M_PI))*
+                            m_generator.m_thetaHarmonics[m_m]);
+                }
             }
 
-            inline std::complex<Real> grad_phi(Real phi, Real theta) const
+            inline std::complex<Real> grad_phi() const
             {
                 std::complex<Real> Ylmp1(0, 0);
                 unsigned int abs_m(m_m);
                 if(m_m < m_l)
-                    Ylmp1 = m_cached_Ylm[m_m + 1];
+                    Ylmp1 = std::complex<Real>(
+                        m_generator.m_legendre[sphIndex(m_l, m_m + 1)]/sqrt(2*M_PI))*
+                        m_generator.m_thetaHarmonics[m_m + 1];
                 else if(m_m > m_l)
                 {
                     abs_m -= m_l;
 
                     if(abs_m == 1)
-                        Ylmp1 = m_cached_Ylm[0];
+                        Ylmp1 = std::complex<Real>(
+                            m_generator.m_legendre[sphIndex(m_l, 0U)]/sqrt(2*M_PI))*
+                            m_generator.m_thetaHarmonics[0];
                     else
-                        Ylmp1 = m_cached_Ylm[m_m - 1];
+                        Ylmp1 = (std::complex<Real>(m_generator.m_legendre[sphIndex(m_l, abs_m - 1)]/sqrt(2*M_PI))*
+                                 std::conj(m_generator.m_thetaHarmonics[abs_m - 1]));
                 }
 
-                return m_evaluators[abs_m].grad_phi(
-                    m_l, this->operator*(), Ylmp1, m_m > m_l);
+                const int m(m_m > m_l? (int) m_l - m_m: m_m);
+                std::complex<Real> result(m*m_generator.m_cphi/m_generator.m_sphi, 0);
+
+                // disregard gradient when phi == 0, for example
+                if(!isfinite(result.real()))
+                    result = 0;
+
+                result *= this->operator*();
+
+                if(m_m != m_l)
+                {
+                    std::complex<Real> additional(sqrt((Real) (m_l - m)*(m_l + m + 1)), 0);
+                    additional *= m_generator.m_gradphi_theta_rotation;
+                    additional *= Ylmp1;
+
+                    if(m_m <= m_l)
+                        additional *= -1;
+
+                    result += additional;
+                }
+                else if(m_m > m_l)
+                    result *= -1;
+
+                return result;
             }
 
             inline std::complex<Real> grad_theta() const
             {
-                const unsigned int abs_m(m_m > m_l? m_m - m_l: m_m);
-                return m_evaluators[abs_m].grad_theta(this->operator*(), m_m > m_l);
+                const int m(m_m > m_l? (int) m_l - m_m: m_m);
+                return std::complex<Real>(0, m)*this->operator*();
             }
 
         private:
@@ -133,46 +150,16 @@ namespace fsph{
             unsigned int m_l;
             unsigned int m_m;
             bool m_full_m;
-            // per-m (with m >= 0) spherical harmonic series
-            // evaluators (each produces for a series of l with a
-            // constant m)
-            std::vector<internal::SPHSeriesEvaluator<Real, std::complex<Real> > > m_evaluators;
-            // per-m spherical harmonics, cached for producing the m<0 values
-            std::vector<std::complex<Real> > m_cached_Ylm;
-
-            void setup(unsigned int l, unsigned int m)
-            {
-                // don't allocate anything when this is just being
-                // used as an end iterator
-                if(l > m_generator.m_lmax)
-                {
-                    m_l = l;
-                    m_m = m;
-                    return;
-                }
-
-                m_evaluators.reserve(m_generator.m_lmax + 1);
-                for(unsigned int m(0); m < m_generator.m_lmax + 1; ++m)
-                {
-                    m_evaluators.push_back(
-                        internal::SPHSeriesEvaluator<Real, std::complex<Real> >(
-                            m, m_generator.m_cphi, m_generator.m_sphi,
-                            m_generator.m_theta, true));
-                }
-
-                // for simplicity, resize to a definitely safe size
-                m_cached_Ylm.resize(2*m_generator.m_lmax + 1);
-
-                m_cached_Ylm[0] = 0.5/sqrt(M_PI);
-
-                while(m_l < l || m_m < m)
-                    this->operator++();
-            }
         };
 
         PointSPHEvaluator(unsigned int lmax):
-            m_lmax(lmax), m_cphi(1), m_sphi(0), m_theta(0)
+            m_lmax(lmax), m_sinPowers(new Real[lmax + 1], lmax + 1),
+            m_thetaHarmonics(new std::complex<Real>[lmax + 1], lmax + 1),
+            m_recurrencePrefactors(new Real[2*(lmax + 1)*lmax], 2*(lmax + 1)*lmax),
+            m_jacobi(new Real[(lmax + 1)*(lmax + 1)], (lmax + 1)*(lmax + 1)),
+            m_legendre(new Real[sphCount(lmax)], sphCount(lmax))
         {
+            evaluatePrefactors();
         }
 
         iterator begin(bool full_m) const
@@ -193,20 +180,114 @@ namespace fsph{
         // phi in [0, pi]; theta in [0, 2*pi]
         void compute(Real phi, Real theta)
         {
-            const Real cphi(cos(phi));
             const Real sphi(sin(phi));
+            compute_sinpows(sphi);
+
+            compute_thetaHarmonics(theta);
+
+            const Real cphi(cos(phi));
+            compute_jacobis(cphi);
+
+            compute_legendres();
+
             m_cphi = cphi;
             m_sphi = sphi;
-            m_theta = theta;
+            m_gradphi_theta_rotation = exp(std::complex<Real>(0, -theta));
         }
     private:
         const unsigned int m_lmax;
-        // last computed cos(phi)
+        // powers of sin(phi)
+        SharedArray<Real> m_sinPowers;
+        // harmonics of theta (e^(1j*m*theta))
+        SharedArray<std::complex<Real> > m_thetaHarmonics;
+        // prefactors for the Jacobi recurrence relation
+        SharedArray<Real> m_recurrencePrefactors;
+        // Jacobi polynomials
+        SharedArray<Real> m_jacobi;
+        // Associated Legendre polynomials
+        SharedArray<Real> m_legendre;
+        // cached rotation for the gradient in phi
+        std::complex<Real> m_gradphi_theta_rotation;
+        // cached cos(phi)
         Real m_cphi;
-        // last computed sin(phi)
+        // cached sin(phi)
         Real m_sphi;
-        // last computed theta
-        Real m_theta;
+
+        void evaluatePrefactors()
+        {
+            const unsigned int f1Count(index2d(m_lmax, m_lmax + 1, 0));
+
+            for(unsigned int m(0); m < m_lmax + 1; ++m)
+            {
+                for(unsigned int l(1); l < m_lmax + 1; ++l)
+                {
+                    const unsigned int idx = index2d(m_lmax, m, l - 1);
+                    m_recurrencePrefactors[idx] =
+                        2*sqrt(1 + (m - 0.5)/l)*sqrt(1 - (m - 0.5)/(l + 2*m));
+                }
+            }
+
+            for(unsigned int m(0); m < m_lmax + 1; ++m)
+            {
+                m_recurrencePrefactors[f1Count + index2d(m_lmax, m, 0)] = 0;
+                for(unsigned int l(2); l < m_lmax + 1; ++l)
+                {
+                    const unsigned int idx = f1Count + index2d(m_lmax, m, l - 1);
+                    m_recurrencePrefactors[idx] =
+                        -sqrt(1.0 + 4.0/(2*l + 2*m - 3))*sqrt(1 - 1.0/l)*sqrt(1.0 - 1.0/(l + 2*m));
+                }
+            }
+        }
+
+        void compute_sinpows(const Real &sphi)
+        {
+            m_sinPowers[0] = 1;
+            for(unsigned int i(1); i < m_lmax + 1; ++i)
+                m_sinPowers[i] = m_sinPowers[i - 1]*sphi;
+        }
+
+        void compute_thetaHarmonics(const Real &theta)
+        {
+            m_thetaHarmonics[0] = std::complex<Real>(1, 0);
+            for(unsigned int i(0); i < m_lmax + 1; ++i)
+                m_thetaHarmonics[i] = exp(std::complex<Real>(0, i*theta));
+        }
+
+        void compute_jacobis(const Real &cphi)
+        {
+            const unsigned int f1Count(index2d(m_lmax, m_lmax + 1, 0));
+
+            for(unsigned int m(0); m < m_lmax + 1; ++m)
+            {
+                if(m > 0)
+                    m_jacobi[index2d(m_lmax + 1, m, 0)] =
+                        m_jacobi[index2d(m_lmax + 1, m - 1, 0)]*sqrt(1 + 1.0/2/m);
+                else
+                    m_jacobi[index2d(m_lmax + 1, (unsigned int) 0, 0)] = 1/sqrt(2);
+
+                if(m_lmax > 0)
+                    m_jacobi[index2d(m_lmax + 1, m, 1)] =
+                        cphi*m_recurrencePrefactors[index2d(m_lmax, m, 0)]*m_jacobi[index2d(m_lmax + 1, m, 0)];
+
+                for(unsigned int l(2); l < m_lmax + 1; ++l)
+                {
+                    m_jacobi[index2d(m_lmax + 1, m, l)] =
+                        (cphi*m_recurrencePrefactors[index2d(m_lmax, m, l - 1)]*m_jacobi[index2d(m_lmax + 1, m, l - 1)] +
+                         m_recurrencePrefactors[f1Count + index2d(m_lmax, m, l - 1)]*m_jacobi[index2d(m_lmax + 1, m, l - 2)]);
+                }
+            }
+        }
+
+        void compute_legendres()
+        {
+            for(unsigned int l(0); l < m_lmax + 1; ++l)
+            {
+                for(unsigned int m(0); m < l + 1; ++m)
+                {
+                    m_legendre[sphIndex(l, m)] = m_sinPowers[m]*m_jacobi[index2d(m_lmax + 1, m, l - m)];
+                }
+            }
+        }
     };
 
     template<typename Real>

--- a/src/tensorflow_op.cpp
+++ b/src/tensorflow_op.cpp
@@ -1,0 +1,174 @@
+
+#include "spherical_harmonics.hpp"
+
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/shape_inference.h"
+
+using namespace tensorflow;
+
+template<typename Real>
+class SphericalHarmonicSeriesOp : public OpKernel {
+public:
+    explicit SphericalHarmonicSeriesOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+    void Compute(OpKernelContext* context) override {
+        const Tensor& input_tensor = context->input(0);
+        auto input_flat = input_tensor.flat<Real>();
+
+        const Tensor& lmax_tensor = context->input(1);
+        const int lmax = lmax_tensor.flat<int>()(0);
+
+        const Tensor& negative_m_tensor = context->input(2);
+        const bool negative_m = negative_m_tensor.flat<bool>()(0);
+
+        int num_sphs(fsph::sphCount(lmax));
+        if(negative_m && lmax >= 1)
+            num_sphs += fsph::sphCount(lmax - 1);
+
+        TensorShape outputShape(input_tensor.shape());
+        outputShape.RemoveLastDims(1);
+        outputShape.AddDim(num_sphs);
+
+        // Create an output tensor
+        Tensor* output_tensor = NULL;
+        OP_REQUIRES_OK(context, context->allocate_output(0, outputShape,
+                                                         &output_tensor));
+        auto output_flat = output_tensor->flat<std::complex<Real> >();
+
+        // Input coordinates consiste of alternating phi (0..pi) and
+        // theta (0..2pi) values
+        const unsigned int N(input_flat.size()/2);
+
+        fsph::PointSPHEvaluator<Real> eval(lmax);
+
+        for (unsigned int i(0); i < N; i++) {
+            const Real phi(input_flat(2*i));
+            const Real theta(input_flat(2*i + 1));
+
+            eval.compute(phi, theta);
+
+            int offset(i*num_sphs);
+            for(typename fsph::PointSPHEvaluator<Real>::iterator iter(eval.begin(negative_m));
+                iter != eval.end(); ++iter)
+                output_flat(offset++) = *iter;
+        }
+
+    }
+};
+
+REGISTER_OP("SphericalHarmonicSeries")
+.Input("coords: float")
+.Input("lmax: int32")
+.Input("negative_m: bool")
+.Output("sphs: complex64")
+.SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {
+    ::tensorflow::shape_inference::ShapeHandle coords_input;
+    TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 1, &coords_input));
+
+    ::tensorflow::shape_inference::DimensionHandle last_dim_handle;
+    TF_RETURN_IF_ERROR(c->WithValue(c->Dim(coords_input, -1), 2, &last_dim_handle));
+
+    ::tensorflow::shape_inference::ShapeHandle lmax_input;
+    TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 0, &lmax_input));
+
+    ::tensorflow::shape_inference::ShapeHandle negative_m_input;
+    TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &negative_m_input));
+
+    ::tensorflow::shape_inference::ShapeHandle output_handle;
+    TF_RETURN_IF_ERROR(c->ReplaceDim(coords_input, -1, c->UnknownDim(), &output_handle));
+    c->set_output(0, output_handle);
+
+    return Status::OK();
+});
+
+REGISTER_KERNEL_BUILDER(
+    Name("SphericalHarmonicSeries")
+    .Device(DEVICE_CPU),
+    SphericalHarmonicSeriesOp<float>);
+
+template<typename Real>
+class SphericalHarmonicSeriesGradOp : public OpKernel {
+public:
+    explicit SphericalHarmonicSeriesGradOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+    void Compute(OpKernelContext* context) override {
+        const Tensor& input_tensor = context->input(0);
+        auto input_flat = input_tensor.flat<Real>();
+
+        const Tensor& lmax_tensor = context->input(1);
+        const int lmax = lmax_tensor.flat<int>()(0);
+
+        const Tensor& negative_m_tensor = context->input(2);
+        const bool negative_m = negative_m_tensor.flat<bool>()(0);
+
+        int num_sphs(fsph::sphCount(lmax));
+        if(negative_m && lmax >= 1)
+            num_sphs += fsph::sphCount(lmax - 1);
+
+        TensorShape outputShape(input_tensor.shape());
+        outputShape.RemoveLastDims(1);
+        outputShape.AddDim(num_sphs);
+        outputShape.AddDim(2);
+
+        // Create an output tensor
+        Tensor* output_tensor = NULL;
+        OP_REQUIRES_OK(context, context->allocate_output(0, outputShape,
+                                                         &output_tensor));
+        auto output_flat = output_tensor->flat<std::complex<Real> >();
+
+        // Input coordinates consiste of alternating phi (0..pi) and
+        // theta (0..2pi) values
+        const unsigned int N(input_flat.size()/2);
+
+        fsph::PointSPHEvaluator<Real> eval(lmax);
+
+        for (unsigned int i(0); i < N; i++) {
+            const Real phi(input_flat(2*i));
+            const Real theta(input_flat(2*i + 1));
+
+            eval.compute(phi, theta);
+
+            int offset(i*num_sphs*2);
+            for(typename fsph::PointSPHEvaluator<Real>::iterator iter(eval.begin(negative_m));
+                iter != eval.end(); ++iter)
+            {
+                output_flat(offset++) = iter.grad_phi(phi, theta);
+                output_flat(offset++) = iter.grad_theta();
+            }
+        }
+
+    }
+};
+
+REGISTER_OP("SphericalHarmonicSeriesGrad")
+.Input("coords: float")
+.Input("lmax: int32")
+.Input("negative_m: bool")
+.Output("sphs: complex64")
+.SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {
+    ::tensorflow::shape_inference::ShapeHandle coords_input;
+    TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 1, &coords_input));
+
+    ::tensorflow::shape_inference::DimensionHandle last_dim_handle;
+    TF_RETURN_IF_ERROR(c->WithValue(c->Dim(coords_input, -1), 2, &last_dim_handle));
+
+    ::tensorflow::shape_inference::ShapeHandle lmax_input;
+    TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 0, &lmax_input));
+
+    ::tensorflow::shape_inference::ShapeHandle negative_m_input;
+    TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 0, &negative_m_input));
+
+    ::tensorflow::shape_inference::ShapeHandle output_handle;
+    ::tensorflow::shape_inference::ShapeHandle extra_dim = c->MakeShape({c->MakeDim(2)});
+    TF_RETURN_IF_ERROR(c->ReplaceDim(coords_input, -1, c->UnknownDim(), &output_handle));
+    TF_RETURN_IF_ERROR(c->Concatenate(output_handle, extra_dim, &output_handle));
+    c->set_output(0, output_handle);
+
+    return Status::OK();
+});
+
+REGISTER_KERNEL_BUILDER(
+    Name("SphericalHarmonicSeriesGrad")
+    .Device(DEVICE_CPU),
+    SphericalHarmonicSeriesGradOp<float>);

--- a/src/tensorflow_op.cpp
+++ b/src/tensorflow_op.cpp
@@ -133,7 +133,7 @@ public:
             for(typename fsph::PointSPHEvaluator<Real>::iterator iter(eval.begin(negative_m));
                 iter != eval.end(); ++iter)
             {
-                output_flat(offset++) = iter.grad_phi(phi, theta);
+                output_flat(offset++) = iter.grad_phi();
                 output_flat(offset++) = iter.grad_theta();
             }
         }

--- a/src/tensorflow_op_gpu.cpp
+++ b/src/tensorflow_op_gpu.cpp
@@ -1,0 +1,101 @@
+
+#include "spherical_harmonics.hpp"
+#include "tensorflow_op_gpu.cu.hpp"
+
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+
+using namespace tensorflow;
+
+template<typename Real>
+class SphericalHarmonicSeriesGPUOp : public OpKernel {
+public:
+    explicit SphericalHarmonicSeriesGPUOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+    void Compute(OpKernelContext* context) override {
+        const Tensor& input_tensor = context->input(0);
+        auto input_flat = input_tensor.flat<Real>();
+
+        // Input coordinates consiste of alternating phi (0..pi) and
+        // theta (0..2pi) values
+        const unsigned int N(input_flat.size()/2);
+
+        const Tensor& lmax_tensor = context->input(1);
+        const int lmax = lmax_tensor.flat<int>()(0);
+
+        const Tensor& negative_m_tensor = context->input(2);
+        const bool negative_m = negative_m_tensor.flat<bool>()(0);
+
+        int num_sphs(fsph::sphCount(lmax));
+        if(negative_m && lmax >= 1)
+            num_sphs += fsph::sphCount(lmax - 1);
+
+        TensorShape outputShape(input_tensor.shape());
+        outputShape.RemoveLastDims(1);
+        outputShape.AddDim(num_sphs);
+
+        // Create an output tensor
+        Tensor* output_tensor = NULL;
+        OP_REQUIRES_OK(context, context->allocate_output(0, outputShape,
+                                                         &output_tensor));
+        auto output_flat = output_tensor->flat<std::complex<Real> >();
+
+        fsph::SphericalHarmonicSeriesKernelLauncher<Real>(
+            input_flat.data(), N, lmax, negative_m,
+            output_flat.data());
+    }
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("SphericalHarmonicSeries")
+    .Device(DEVICE_GPU)
+    .HostMemory("lmax")
+    .HostMemory("negative_m"),
+    SphericalHarmonicSeriesGPUOp<float>);
+
+template<typename Real>
+class SphericalHarmonicSeriesGradGPUOp : public OpKernel {
+public:
+    explicit SphericalHarmonicSeriesGradGPUOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+    void Compute(OpKernelContext* context) override {
+        const Tensor& input_tensor = context->input(0);
+        auto input_flat = input_tensor.flat<Real>();
+
+        // Input coordinates consiste of alternating phi (0..pi) and
+        // theta (0..2pi) values
+        const unsigned int N(input_flat.size()/2);
+
+        const Tensor& lmax_tensor = context->input(1);
+        const int lmax = lmax_tensor.flat<int>()(0);
+
+        const Tensor& negative_m_tensor = context->input(2);
+        const bool negative_m = negative_m_tensor.flat<bool>()(0);
+
+        int num_sphs(fsph::sphCount(lmax));
+        if(negative_m && lmax >= 1)
+            num_sphs += fsph::sphCount(lmax - 1);
+
+        TensorShape outputShape(input_tensor.shape());
+        outputShape.RemoveLastDims(1);
+        outputShape.AddDim(num_sphs);
+        outputShape.AddDim(2);
+
+        // Create an output tensor
+        Tensor* output_tensor = NULL;
+        OP_REQUIRES_OK(context, context->allocate_output(0, outputShape,
+                                                         &output_tensor));
+        auto output_flat = output_tensor->flat<std::complex<Real> >();
+
+        fsph::SphericalHarmonicSeriesGradKernelLauncher<Real>(
+            input_flat.data(), N, lmax, negative_m,
+            output_flat.data());
+    }
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("SphericalHarmonicSeriesGrad")
+    .Device(DEVICE_GPU)
+    .HostMemory("lmax")
+    .HostMemory("negative_m"),
+    SphericalHarmonicSeriesGradGPUOp<float>);

--- a/src/tensorflow_op_gpu.cu
+++ b/src/tensorflow_op_gpu.cu
@@ -1,0 +1,151 @@
+
+#include "tensorflow_op_gpu.cu.hpp"
+#include "internal.hpp"
+#include "../cuda_complex/cuda_complex.hpp"
+
+namespace fsph{
+    template<typename Real, typename Complex>
+    __global__ void SphericalHarmonicSeriesKernel(
+        const Real *__restrict__ phitheta, const unsigned int N,
+        const unsigned int lmax, const bool full_m,
+        Complex *__restrict__ output)
+    {
+#define POINT_INDEX (blockIdx.x*blockDim.y + threadIdx.y)
+#define INITIAL_M (blockIdx.y*blockDim.x + threadIdx.x)
+        if(POINT_INDEX > N || INITIAL_M > (lmax + 1)/2 + 1)
+            return;
+
+        const Real phi(phitheta[2*POINT_INDEX]);
+        Real sphi, cphi;
+        sincosf(phi, &sphi, &cphi);
+        const Real theta(phitheta[2*POINT_INDEX + 1]);
+
+        unsigned int m(INITIAL_M);
+        unsigned int l(m);
+        fsph::internal::SPHSeriesEvaluator<Real, Complex> eval(m, cphi, sphi, theta, false);
+
+        for(unsigned int i(0); i < lmax + 1; i++)
+        {
+            if(l > lmax)
+            {
+                m = lmax - INITIAL_M + 1;
+                l = m;
+                eval.reset(m, cphi, sphi, theta, false);
+            }
+
+            const Complex Ylm(eval.get(l));
+
+            const unsigned int sph_per_point(
+                (lmax + 1)*(lmax + 2)/2 + full_m*lmax*(lmax + 1)/2);
+            const unsigned int sph_index(
+                POINT_INDEX*sph_per_point +
+                l*(l + 1)/2 + full_m*(l - 1)*l/2 + m);
+            output[sph_index] = Ylm;
+
+            if(full_m && m)
+                output[sph_index + l] = eval.get_negative_m(Ylm);
+
+            l++;
+        }
+    }
+
+    template<typename Real>
+    void SphericalHarmonicSeriesKernelLauncher(
+        const Real *phitheta, const unsigned int N,
+        const unsigned int lmax, const bool full_m,
+        std::complex<Real> *output)
+    {
+        const unsigned int points_per_block(32);
+        const unsigned int num_blocks((N + points_per_block - 1)/points_per_block);
+        const unsigned int m_workers_needed((lmax + 1)/2 + 1);
+        const dim3 block_dim(min(m_workers_needed, 1024/points_per_block), points_per_block);
+        const dim3 grid_dim(num_blocks, (m_workers_needed + block_dim.x - 1)/block_dim.x);
+
+        SphericalHarmonicSeriesKernel<Real, complex<Real> ><<<grid_dim, block_dim>>>(
+            phitheta, N, lmax, full_m, (complex<Real>*) output);
+    }
+
+    template<typename Real, typename Complex>
+    __global__ void SphericalHarmonicSeriesGradKernel(
+        const Real *__restrict__ phitheta, const unsigned int N,
+        const unsigned int lmax, const bool full_m,
+        Complex *__restrict__ output)
+    {
+#define POINT_INDEX (blockIdx.x*blockDim.y + threadIdx.y)
+#define INITIAL_M (blockIdx.y*blockDim.x + threadIdx.x)
+        if(POINT_INDEX > N || INITIAL_M > (lmax + 1)/2 + 1)
+            return;
+
+        const Real phi(phitheta[2*POINT_INDEX]);
+        Real sphi, cphi;
+        sincosf(phi, &sphi, &cphi);
+        const Real theta(phitheta[2*POINT_INDEX + 1]);
+
+        unsigned int m(INITIAL_M);
+        unsigned int l(m);
+        fsph::internal::SPHSeriesEvaluator<Real, Complex> eval(m, cphi, sphi, theta, true);
+        fsph::internal::SPHSeriesEvaluator<Real, Complex> evalmp1(m + 1, cphi, sphi, theta, false);
+        fsph::internal::SPHSeriesEvaluator<Real, Complex> evalmm1(m? m - 1: 0, cphi, sphi, theta, false);
+
+        for(unsigned int i(0); i < lmax + 1; i++)
+        {
+            if(l > lmax)
+            {
+                m = lmax - INITIAL_M + 1;
+                l = m;
+                eval.reset(m, cphi, sphi, theta, true);
+                evalmp1.reset(m + 1, cphi, sphi, theta, false);
+                evalmm1.reset(m? m - 1: 0, cphi, sphi, theta, false);
+            }
+
+            const Complex Ylm(eval.get(l));
+            const Complex Ylmp1(evalmp1.get(l));
+
+            const unsigned int sph_per_point(
+                (lmax + 1)*(lmax + 2)/2 + full_m*lmax*(lmax + 1)/2);
+            const unsigned int sph_index(
+                POINT_INDEX*sph_per_point +
+                l*(l + 1)/2 + full_m*(l - 1)*l/2 + m);
+            output[2*sph_index] = eval.grad_phi(l, Ylm, Ylmp1, false);
+            output[2*sph_index + 1] = eval.grad_theta(Ylm, false);
+
+            if(full_m && m)
+            {
+                const Complex Ylmm1(evalmm1.get(l));
+                const Complex Ylnegm(eval.get_negative_m(Ylm));
+                const Complex Ylnegmp1(evalmm1.get_negative_m(Ylmm1));
+
+                output[2*(sph_index + l)] = eval.grad_phi(l, Ylnegm, Ylnegmp1, true);
+                output[2*(sph_index + l) + 1] = eval.grad_theta(Ylnegm, true);
+            }
+
+            l++;
+        }
+    }
+
+    template<typename Real>
+    void SphericalHarmonicSeriesGradKernelLauncher(
+        const Real *phitheta, const unsigned int N,
+        const unsigned int lmax, const bool full_m,
+        std::complex<Real> *output)
+    {
+        const unsigned int points_per_block(32);
+        const unsigned int num_blocks((N + points_per_block - 1)/points_per_block);
+        const unsigned int m_workers_needed((lmax + 1)/2 + 1);
+        const dim3 block_dim(min(m_workers_needed, 1024/points_per_block), points_per_block);
+        const dim3 grid_dim(num_blocks, (m_workers_needed + block_dim.x - 1)/block_dim.x);
+
+        SphericalHarmonicSeriesGradKernel<Real, complex<Real> ><<<grid_dim, block_dim>>>(
+            phitheta, N, lmax, full_m, (complex<Real>*) output);
+    }
+}
+
+template void fsph::SphericalHarmonicSeriesKernelLauncher<float>(
+    const float *phitheta, const unsigned int N,
+    const unsigned int lmax, const bool full_m,
+    std::complex<float> *output);
+
+template void fsph::SphericalHarmonicSeriesGradKernelLauncher<float>(
+    const float *phitheta, const unsigned int N,
+    const unsigned int lmax, const bool full_m,
+    std::complex<float> *output);

--- a/src/tensorflow_op_gpu.cu.hpp
+++ b/src/tensorflow_op_gpu.cu.hpp
@@ -1,0 +1,15 @@
+#include <complex>
+
+namespace fsph{
+    template<typename Real>
+    void SphericalHarmonicSeriesKernelLauncher(
+        const Real *phitheta, const unsigned int N,
+        const unsigned int lmax, const bool full_m,
+        std::complex<Real> *output);
+
+    template<typename Real>
+    void SphericalHarmonicSeriesGradKernelLauncher(
+        const Real *phitheta, const unsigned int N,
+        const unsigned int lmax, const bool full_m,
+        std::complex<Real> *output);
+}

--- a/tests/benchmark_scipy.py
+++ b/tests/benchmark_scipy.py
@@ -1,70 +1,115 @@
-from collections import defaultdict
+import argparse
+import itertools
 import timeit
-import matplotlib, matplotlib.pyplot as pp
 
-setup = """
+import fsph
+import matplotlib, matplotlib.pyplot as pp
 import numpy as np
 import scipy as sp, scipy.special
-import fsph
 
-N = {N}
-lmax = {lmax}
+class Benchmark:
+    def __init__(self, N, lmax, negative_m):
+        self.N = N
+        self.lmax = lmax
+        self.negative_m = negative_m
 
-phis = np.random.uniform(-np.pi, np.pi, size=(N,))
-thetas = np.random.uniform(0, 2*np.pi, size=(N,))
+        self.phis = np.random.uniform(0, np.pi, size=(N,))
+        self.thetas = np.random.uniform(0, 2*np.pi, size=(N,))
 
-def Ylm_scipy(phis, thetas, lmax):
-    result = []
-    for l in range(lmax):
-        for m in range(-l, l+1):
-            result.append(sp.special.sph_harm(m, l, phis, thetas))
+class BenchmarkScipy(Benchmark):
+    def __call__(self):
+        result = []
+        for l in range(self.lmax + 1):
+            for m in range(l + 1):
+                result.append(sp.special.sph_harm(m, l, self.thetas, self.phis)*(-1)**m)
+            if self.negative_m:
+                for m in range(1, l + 1):
+                    result.append(sp.special.sph_harm(-m, l, self.thetas, self.phis))
 
-    return result
+        return result
 
-def Ylm_fsph(phis, thetas, lmax):
-    result = fsph.pointwise_sph(phis, thetas, lmax)
-    return result
-"""
+class BenchmarkFSPH(Benchmark):
+    def __call__(self):
+        return fsph.pointwise_sph(self.phis, self.thetas, self.lmax, self.negative_m)
 
-dsets = {}
+parser = argparse.ArgumentParser('Run scipy benchmarks')
+parser.add_argument('-l', nargs='*', default=[12, 32, 64],
+    help='Spherical harmonic l values to use')
+parser.add_argument('-n', nargs='*', default=[1024, 2048, 4096],
+    help='Number of points to compute for')
+parser.add_argument('-r', '--replicas', type=int, default=3,
+    help='Number of repeats to do for benchmarking purposes')
+parser.add_argument('--negative-m', action='store_true',
+    help='Compute spherical harmonics with negative m values')
+parser.add_argument('-x', '--x-axis', default='lmax', choices=['n', 'lmax'],
+    help='X-axis value to use')
+parser.add_argument('--absolute', action='store_true',
+    help='Plot absolute speed, rather than relative speedups')
+parser.add_argument('-o', '--output',
+    help='Output location')
 
-lmaxs = [4, 6, 8, 10, 12, 14,16, 20, 24, 32, 48, 64]
-Ns = [1000]
+def main(l, n, replicas, negative_m, x_axis, absolute, output):
+    dsets = {}
 
-for lmax in lmaxs:
-    for N in Ns:
-        time_scipy = timeit.timeit(stmt='Ylm_scipy(phis, thetas, lmax)', setup=setup.format(N=N, lmax=lmax), number=10)
-        time_fsph = timeit.timeit(stmt='Ylm_fsph(phis, thetas, lmax)', setup=setup.format(N=N, lmax=lmax), number=10)
+    lmaxs = list(map(int, l))
+    Ns = list(map(int, n))
 
+    for (lmax, N) in itertools.product(lmaxs, Ns):
+        time_scipy = timeit.timeit(
+            stmt=BenchmarkScipy(N, lmax, negative_m), number=replicas)
         dsets[(N, lmax, 'scipy')] = time_scipy
+
+        time_fsph = timeit.timeit(
+            stmt=BenchmarkFSPH(N, lmax, negative_m), number=replicas)
         dsets[(N, lmax, 'fsph')] = time_fsph
 
-mode = 'x_lmax'
-if mode == 'x_N':
-    for lmax in lmaxs:
-        xs = list(sorted({N for (N, lmax_, typ) in dsets if lmax_ == lmax and typ == 'fsph'}))
-        ys = [dsets[(N, lmax, 'fsph')] for N in xs]
-        pp.plot(xs, ys, label='$fsph_{{{}}}$'.format(lmax))
+    colors = pp.rcParams['axes.prop_cycle'].by_key()['color']
 
-        xs = list(sorted({N for (N, lmax_, typ) in dsets if lmax_ == lmax and typ == 'scipy'}))
-        ys = [dsets[(N, lmax, 'scipy')] for N in xs]
-        pp.plot(xs, ys, '--', label='$scipy_{{{}}}$'.format(lmax))
+    if x_axis.lower() == 'n':
+        for (lmax, color) in zip(lmaxs, colors):
+            xs = Ns
+            ys_fsph = [dsets[(N, lmax, 'fsph')] for N in xs]
+            ys_scipy = [dsets[(N, lmax, 'scipy')] for N in xs]
 
-    pp.xlabel('N')
-    pp.ylabel('t/s')
-    pp.legend(loc='best')
-elif mode == 'x_lmax':
-    for N in Ns:
-        xs = list(sorted({lmax for (N_, lmax, typ) in dsets if N_ == N and typ == 'fsph'}))
-        ys = [dsets[(N, lmax, 'fsph')] for lmax in xs]
-        pp.plot(xs, ys, label='$fsph_{{{}}}$'.format(N))
+            if absolute:
+                pp.plot(xs, ys_fsph, label='$fsph_{{{}}}$'.format(lmax), color=color)
+                pp.plot(xs, ys_scipy, '--', label='$scipy_{{{}}}$'.format(lmax), color=color)
+            else:
+                ys = np.array(ys_scipy)/np.array(ys_fsph)
+                pp.plot(xs, ys, label='$lmax={}$'.format(lmax), color=color)
 
-        xs = list(sorted({lmax for (N_, lmax, typ) in dsets if N_ == N and typ == 'scipy'}))
-        ys = [dsets[(N, lmax, 'scipy')] for lmax in xs]
-        pp.plot(xs, ys, '--', label='$scipy_{{{}}}$'.format(N))
+        pp.xlabel('N')
+        if absolute:
+            pp.ylabel('t/s')
+        else:
+            pp.ylabel('speedup')
+        pp.legend(loc='best')
 
-    pp.xlabel('$l_{max}$')
-    pp.ylabel('t/s')
-    pp.legend(loc='best')
+    elif x_axis.lower() == 'lmax':
+        for (N, color) in zip(Ns, colors):
+            xs = lmaxs
+            ys_fsph = [dsets[(N, lmax, 'fsph')] for lmax in xs]
+            ys_scipy = [dsets[(N, lmax, 'scipy')] for lmax in xs]
 
-pp.savefig('/tmp/fsph_benchmark.png')
+            if absolute:
+                pp.plot(xs, ys_fsph, label='$fsph_{{{}}}$'.format(N), color=color)
+                pp.plot(xs, ys_scipy, '--', label='$scipy_{{{}}}$'.format(N), color=color)
+            else:
+                ys = np.array(ys_scipy)/np.array(ys_fsph)
+                pp.plot(xs, ys, label='$N={}$'.format(N), color=color)
+
+        pp.xlabel('$l_{max}$')
+        if absolute:
+            pp.ylabel('t/s')
+        else:
+            pp.ylabel('speedup')
+        pp.legend(loc='best')
+    else:
+        raise NotImplementedError(x_axis)
+
+    if output:
+        pp.savefig(output)
+    else:
+        pp.show()
+
+if __name__ == '__main__': main(**vars(parser.parse_args()))

--- a/tests/benchmark_tf.py
+++ b/tests/benchmark_tf.py
@@ -1,0 +1,104 @@
+import argparse
+import itertools
+import timeit
+
+import fsph, fsph.tf_ops
+import matplotlib, matplotlib.pyplot as pp
+import numpy as np
+import tensorflow as tf
+
+class Benchmark:
+    def __init__(self, N, lmax, negative_m, compute_grad):
+        self.N = N
+        self.lmax = lmax
+        self.negative_m = negative_m
+        self.compute_grad = compute_grad
+
+        self.phis = np.random.uniform(0, np.pi, size=(N,))
+        self.thetas = np.random.uniform(0, 2*np.pi, size=(N,))
+
+        self.inputs = np.array([self.phis, self.thetas], dtype=np.float32).T
+
+class BenchmarkTF(Benchmark):
+    _device_map = dict(cpu='/cpu:0', gpu='/device:GPU:0')
+
+    def __init__(self, N, lmax, negative_m, compute_grad, device):
+        super().__init__(N, lmax, negative_m, compute_grad)
+        self.device = self._device_map[device]
+
+    @staticmethod
+    @tf.function
+    def compute(x, lmax, negative_m, compute_grad):
+        if compute_grad:
+            return fsph.tf_ops.spherical_harmonic_series_grad(x, lmax, negative_m)
+        else:
+            return fsph.tf_ops.spherical_harmonic_series(x, lmax, negative_m)
+
+    def __call__(self):
+        with tf.device(self.device):
+            return self.compute(self.inputs, self.lmax, self.negative_m, self.compute_grad)
+
+class BenchmarkFSPH(Benchmark):
+    def __call__(self):
+        return fsph.pointwise_sph(self.phis, self.thetas, self.lmax, self.negative_m)
+
+parser = argparse.ArgumentParser('Run tensorflow benchmarks')
+parser.add_argument('-l', nargs='*', default=[12, 32, 64],
+    help='Spherical harmonic l values to use')
+parser.add_argument('--n-min', type=int, default=1024,
+    help='Minimum number of points to use')
+parser.add_argument('--n-max', type=int, default=16384,
+    help='Maximum number of points to use')
+parser.add_argument('--num-n', type=int, default=6,
+    help='Number of values between --n-min and --n-max to sample')
+parser.add_argument('-r', '--replicas', type=int, default=3,
+    help='Number of repeats to do for benchmarking purposes')
+parser.add_argument('--negative-m', action='store_true',
+    help='Compute spherical harmonics with negative m values')
+parser.add_argument('-g', '--compute-gradient', action='store_true',
+    help='Compute the gradient, rather than the raw spherical harmonic values')
+parser.add_argument('-o', '--output',
+    help='Output location')
+
+def main(l, n_min, n_max, num_n, replicas, negative_m, compute_gradient, output):
+    dsets = {}
+
+    lmaxs = list(map(int, l))
+    Ns = np.linspace(n_min, n_max, num_n).astype(int)
+
+    for (lmax, N) in itertools.product(lmaxs, Ns):
+        if not compute_gradient:
+            time_fsph = timeit.timeit(
+                stmt=BenchmarkFSPH(N, lmax, negative_m, compute_gradient), number=replicas)
+            dsets[(N, lmax, 'fsph')] = time_fsph
+
+        time_cpu = timeit.timeit(
+            stmt=BenchmarkTF(N, lmax, negative_m, compute_gradient, 'cpu'), number=replicas)
+        dsets[(N, lmax, 'cpu')] = time_cpu
+
+        time_gpu = timeit.timeit(
+            stmt=BenchmarkTF(N, lmax, negative_m, compute_gradient, 'gpu'), number=replicas)
+        dsets[(N, lmax, 'gpu')] = time_gpu
+
+    for (lmax, color) in zip(lmaxs, pp.rcParams['axes.prop_cycle'].by_key()['color']):
+        xs = Ns
+
+        if (N, lmax, 'fsph') in dsets:
+            ys = [dsets[(N, lmax, 'fsph')]/dsets[(N, lmax, 'cpu')] for N in Ns]
+            pp.plot(xs, ys, '--', color=color)
+            ys = [dsets[(N, lmax, 'fsph')]/dsets[(N, lmax, 'gpu')] for N in Ns]
+            pp.plot(xs, ys, '-', label='l={}'.format(lmax), color=color)
+        else:
+            ys = [dsets[(N, lmax, 'cpu')]/dsets[(N, lmax, 'gpu')] for N in Ns]
+            pp.plot(xs, ys, label='l={}'.format(lmax), color=color)
+
+    pp.xlabel('N_points')
+    pp.ylabel('speedup')
+    pp.legend()
+
+    if output:
+        pp.savefig(output)
+    else:
+        pp.show()
+
+if __name__ == '__main__': main(**vars(parser.parse_args()))

--- a/tests/test_boost.cpp
+++ b/tests/test_boost.cpp
@@ -1,0 +1,73 @@
+
+#include <boost/math/special_functions/spherical_harmonic.hpp>
+#include <iostream>
+
+#include "../src/spherical_harmonics.hpp"
+
+using namespace fsph;
+using namespace boost::math;
+
+int main(int argc, char **argv)
+{
+    unsigned int lmax(5);
+    float phi(0.25), theta(1.5*M_PI);
+
+    PointSPHEvaluator<float> eval(lmax);
+    eval.compute(phi, theta);
+    PointSPHEvaluator<float>::iterator iter(eval.begin(true));
+
+    double error(0);
+    unsigned int N(0);
+
+    for(unsigned int l(0); l <= lmax; ++l)
+    {
+        for(unsigned int m(0); m <= l; ++m)
+        {
+            std::complex<float> from_fsph(*iter);
+            // std::cout << iter.grad_phi(phi, theta) << ' ' << iter.grad_theta() << std::endl;
+            // boost names phi and theta using the opposite convention
+            std::complex<float> from_boost(spherical_harmonic(l, m, phi, theta));
+            from_boost *= pow(-1, m);
+            error += abs(from_fsph - from_boost);
+            if(abs(from_fsph - from_boost) > 1e-5)
+                std::cout << l << ' ' << m << ' ' << from_fsph << ' ' << from_boost << std::endl;
+            ++N;
+            ++iter;
+        }
+        for(unsigned int m(1); m <= l; ++m)
+        {
+            std::complex<float> from_fsph(*iter);
+            // std::cout << iter.grad_phi(phi, theta) << ' ' << iter.grad_theta() << std::endl;
+            // boost names phi and theta using the opposite convention
+            std::complex<float> from_boost(spherical_harmonic(l, -(int)m, phi, theta));
+            error += abs(from_fsph - from_boost);
+            if(abs(from_fsph - from_boost) > 1e-5)
+                std::cout << l << ' ' << m << ' ' << from_fsph << ' ' << from_boost << std::endl;
+            ++N;
+            ++iter;
+        }
+    }
+
+    const unsigned int start_l(2);
+    const unsigned int start_m(1);
+    PointSPHEvaluator<float>::iterator iter_l(eval.begin_l(start_l, start_m, false));
+
+    for(unsigned int l(start_l); l <= lmax; ++l)
+    {
+        for(unsigned int m(l == start_l? start_m: 0); m <= l; ++m)
+        {
+            std::complex<float> from_fsph(*iter_l);
+            // std::cout << iter_l.grad_phi(phi, theta) << ' ' << iter_l.grad_theta() << std::endl;
+            // boost names phi and theta using the opposite convention
+            std::complex<float> from_boost(spherical_harmonic(l, m, phi, theta));
+            from_boost *= pow(-1, m);
+            error += abs(from_fsph - from_boost);
+            if(abs(from_fsph - from_boost) > 1e-5)
+                std::cout << l << ' ' << m << ' ' << from_fsph << ' ' << from_boost << std::endl;
+            ++N;
+            ++iter_l;
+        }
+    }
+
+    return error/N > 1e-7;
+}

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -1,0 +1,31 @@
+import unittest
+
+import hypothesis as hp, hypothesis.strategies as hps
+import numpy as np
+import scipy as sp, scipy.special
+import fsph
+
+def Ylm_scipy(phis, thetas, lmax):
+    result = []
+    for l in range(lmax + 1):
+        for m in range(l + 1):
+            result.append(sp.special.sph_harm(m, l, thetas, phis)*(-1)**m)
+        for m in range(1, l + 1):
+            result.append(sp.special.sph_harm(-m, l, thetas, phis))
+
+    return np.transpose(result)
+
+class TestScipy(unittest.TestCase):
+    @hp.given(hps.integers(0, 64), hps.floats(0, np.pi, False, False),
+              hps.floats(0, 2*np.pi, False, False))
+    def test_values(self, lmax, phi, theta):
+        phis = np.array([phi])
+        thetas = np.array([theta])
+
+        Ys_scipy = Ylm_scipy(phis, thetas, lmax)
+        Ys_fsph = fsph.pointwise_sph(phis, thetas, lmax)
+
+        np.testing.assert_allclose(Ys_fsph, Ys_scipy, atol=1e-6)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_tensorflow.py
+++ b/tests/test_tensorflow.py
@@ -1,0 +1,84 @@
+import functools
+import unittest
+
+import hypothesis as hp, hypothesis.strategies as hps
+import hypothesis.extra.numpy as hpn
+import numpy as np
+import tensorflow as tf
+import fsph, fsph.tf_ops
+
+class TestTensorflow(unittest.TestCase):
+    @hp.settings(deadline=None, print_blob=True)
+    @hp.given(hps.integers(0, 64), hps.booleans(),
+              hpn.arrays(np.float32, hpn.array_shapes(max_dims=1),
+                         hps.floats(0, np.pi, False, False, width=32)),
+              hpn.arrays(np.float32, hpn.array_shapes(max_dims=1),
+                         hps.floats(0, 2*np.pi, False, False, width=32)))
+    def test_basic(self, lmax, negative_m, phis, thetas):
+        phis = phis[:min(len(phis), len(thetas))]
+        thetas = thetas[:min(len(phis), len(thetas))]
+
+        Ys_fsph = fsph.pointwise_sph(phis, thetas, lmax, negative_m)
+
+        inputs = np.array([phis, thetas]).T
+
+        Ys_tf = fsph.tf_ops.spherical_harmonic_series(inputs, lmax, negative_m)
+
+        self.assertEqual(Ys_fsph.shape, Ys_tf.shape)
+        np.testing.assert_allclose(Ys_fsph, Ys_tf, atol=1e-4)
+
+    @hp.settings(deadline=None, print_blob=True)
+    @hp.given(hps.integers(0, 12), hps.booleans(),
+              hpn.arrays(np.float32, hpn.array_shapes(max_dims=1),
+                         hps.floats(np.float32(.1),
+                                    np.float32(np.pi - .1), False, False, width=32)),
+              hpn.arrays(np.float32, hpn.array_shapes(max_dims=1),
+                         hps.floats(np.float32(.1),
+                                    np.float32(2*np.pi - .1), False, False, width=32)))
+    def test_numeric_gradient(self, lmax, negative_m, phis, thetas):
+        phis = phis[:min(len(phis), len(thetas))]
+        thetas = thetas[:min(len(phis), len(thetas))]
+
+        Y0 = fsph.pointwise_sph(phis, thetas, lmax, negative_m)
+        grad_numeric = []
+        for dim in range(2):
+            dx = 1e-3
+            if dim == 0:
+                Y = fsph.pointwise_sph(phis + dx, thetas, lmax, negative_m)
+            else:
+                Y = fsph.pointwise_sph(phis, thetas + dx, lmax, negative_m)
+
+            dY = Y - Y0
+            grad_numeric.append(dY/dx)
+
+        grad_numeric = np.transpose(grad_numeric, (1, 2, 0))
+
+        inputs = np.array([phis, thetas]).T
+
+        grad_tf = fsph.tf_ops.spherical_harmonic_series_grad(inputs, lmax, negative_m)
+
+        np.testing.assert_allclose(grad_numeric, grad_tf, atol=5e-2)
+
+    @hp.settings(deadline=None, print_blob=True)
+    @hp.given(hps.integers(0, 12), hps.booleans(),
+              hpn.arrays(np.float32, hpn.array_shapes(max_dims=1),
+                         hps.floats(np.float32(.1),
+                                    np.float32(np.pi - .1), False, False, width=32)),
+              hpn.arrays(np.float32, hpn.array_shapes(max_dims=1),
+                         hps.floats(np.float32(.1),
+                                    np.float32(2*np.pi - .1), False, False, width=32)))
+    def test_tf_gradient(self, lmax, negative_m, phis, thetas):
+        phis = phis[:min(len(phis), len(thetas))]
+        thetas = thetas[:min(len(phis), len(thetas))]
+        inputs = np.array([phis, thetas]).T
+
+        test_fun = functools.partial(
+            fsph.tf_ops.spherical_harmonic_series,
+            lmax=lmax, negative_m=negative_m)
+
+        (exact, numeric) = tf.test.compute_gradient(test_fun, [inputs])
+
+        np.testing.assert_allclose(exact, numeric, atol=5e-2)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_tensorflow.py
+++ b/tests/test_tensorflow.py
@@ -11,9 +11,9 @@ class TestTensorflow(unittest.TestCase):
     @hp.settings(deadline=None, print_blob=True)
     @hp.given(hps.integers(0, 64), hps.booleans(),
               hpn.arrays(np.float32, hpn.array_shapes(max_dims=1),
-                         hps.floats(0, np.pi, False, False, width=32)),
+                         hps.floats(0, np.float32(np.pi), False, False, width=32)),
               hpn.arrays(np.float32, hpn.array_shapes(max_dims=1),
-                         hps.floats(0, 2*np.pi, False, False, width=32)))
+                         hps.floats(0, np.float32(2*np.pi), False, False, width=32)))
     def test_basic(self, lmax, negative_m, phis, thetas):
         phis = phis[:min(len(phis), len(thetas))]
         thetas = thetas[:min(len(phis), len(thetas))]


### PR DESCRIPTION
This PR adds a tensorflow operation that performs the spherical harmonic series calculation for a set of points, as well as the gradient of that value to be useful in neural network layers (like the `learned_representations` branch of pythia). It includes GPU and CPU support, as well as code to iterate over the spherical harmonics by `m` first, rather than `l`, as that requires less working memory. 

Currently the library automatically attempts to create the tensorflow extension if tensorflow can be imported, and tries to compile the cuda portion if cuda is found. I didn't want to adopt the complicated-looking structure from the tensorflow documentation for how to set up a project the "right" way, so it is possible that this build structure doesn't work on all platforms, which is why I would like to hear from others if the build is successful.