### PR TITLE
Adding extra args to help with compiling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,15 @@ from distutils.command.build_ext import build_ext
 from distutils.core import Extension, setup
 from distutils import log
 import os
+import platform
 import shutil
 import subprocess
 import sys
 import numpy
+
+# Ensure that builds on Mac use correct stdlib.
+if platform.system() == 'Darwin':
+    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.12"
 
 with open('fsph/version.py') as version_file:
     exec(version_file.read())

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import numpy
 
 # Ensure that builds on Mac use correct stdlib.
 if platform.system() == 'Darwin':
-    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.12"
+    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.15"
 
 with open('fsph/version.py') as version_file:
     exec(version_file.read())


### PR DESCRIPTION
Without these args, on OSX Catalina (10.15.4) throws the error:

```In file included from fsph/_fsph.cpp:603:
fsph/../src/spherical_harmonics.hpp:1:10: fatal error: 'iostream.h' file not found
#include <iostream>```

for many "includes" in multiple files. This fix is modeled after a solution from [this random issue discussion](https://github.com/wouterboomsma/eigency/issues/32) which fixed the problem.